### PR TITLE
Fixed lore, will drop input/output when broken

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/Items.java
+++ b/src/main/java/me/gallowsdove/foxymachines/Items.java
@@ -82,7 +82,7 @@ public final class Items{
     "HEALING_BOW",
     Material.BOW,
     "&4Healing Bow",
-    "Healing II",
+    "&cHealing II",
     "",
     "&8Finally a support weapon."
   );
@@ -98,7 +98,7 @@ public final class Items{
     Material.SMITHING_TABLE,
     "&bImprovement Forge",
     "",
-    "Used to improve Slimefun tools, weapons and armor.",
+    "&7Used to improve Slimefun tools, weapons and armor.",
     "",
     LoreBuilder.machine(MachineTier.ADVANCED, MachineType.MACHINE),
     LoreBuilder.powerPerSecond(ImprovementForge.ENERGY_CONSUMPTION)
@@ -109,7 +109,7 @@ public final class Items{
     "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmFmZjJlYjQ5OGU1YzZhMDQ0ODRmMGM5Zjc4NWI0NDg0NzlhYjIxM2RmOTVlYzkxMTc2YTMwOGExMmFkZDcwIn19fQ==",
     "&aImprovement Core",
     "",
-    "Combine it with a tool in Improvement Forge to improve it."
+    "&7Combine it with a tool in Improvement Forge to improve it."
   );
 
   public static final SlimefunItemStack POTION_MIXER = new SlimefunItemStack(
@@ -117,7 +117,7 @@ public final class Items{
     Material.BREWING_STAND	,
     "&bPotion Mixer",
     "",
-    "Used to mix potions.",
+    "&7Used to mix potions.",
     "",
     LoreBuilder.machine(MachineTier.GOOD, MachineType.MACHINE),
     LoreBuilder.powerPerSecond(PotionMixer.ENERGY_CONSUMPTION)

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
@@ -123,6 +123,10 @@ public class ImprovementForge extends SlimefunItem implements InventoryBlock, En
     });
   }
 
+  private Comparator<Integer> compareSlots(DirtyChestMenu menu){
+    return Comparator.comparingInt(slot -> menu.getItemInSlot(slot).getAmount());
+  }
+
   @Override
   public int[] getInputSlots() {
     return new int[] { 19, 20 };

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
@@ -110,10 +110,17 @@ public class ImprovementForge extends SlimefunItem implements InventoryBlock, En
         return array;
       }
     };
-  }
+    
+    registerBlockHandler(getID(), (p, b, stack, reason) -> {
+      BlockMenu inv = BlockStorage.getInventory(b);
+      
+      if (inv != null) {
+        inv.dropItems(b.getLocation(), getOutputSlots());
+        inv.dropItems(b.getLocation(), getInputSlots());
+      }
 
-  private Comparator<Integer> compareSlots(DirtyChestMenu menu) {
-    return Comparator.comparingInt(slot -> menu.getItemInSlot(slot).getAmount());
+      return true;
+    });
   }
 
   @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
@@ -123,7 +123,7 @@ public class ImprovementForge extends SlimefunItem implements InventoryBlock, En
     });
   }
 
-  private Comparator<Integer> compareSlots(DirtyChestMenu menu){
+  private Comparator<Integer> compareSlots(DirtyChestMenu menu) {
     return Comparator.comparingInt(slot -> menu.getItemInSlot(slot).getAmount());
   }
 

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/PotionMixer.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/PotionMixer.java
@@ -109,6 +109,17 @@ public class PotionMixer extends SlimefunItem implements InventoryBlock, EnergyN
         return array;
       }
     };
+    
+    registerBlockHandler(getID(), (p, b, stack, reason) -> {
+      BlockMenu inv = BlockStorage.getInventory(b);
+      
+      if (inv != null) {
+        inv.dropItems(b.getLocation(), getOutputSlots());
+        inv.dropItems(b.getLocation(), getInputSlots());
+      }
+
+      return true;
+    });
   }
 
   private Comparator<Integer> compareSlots(DirtyChestMenu menu) {

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/PotionMixer.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/PotionMixer.java
@@ -386,6 +386,7 @@ public class PotionMixer extends SlimefunItem implements InventoryBlock, EnergyN
           lingering = true;
         }
         ItemStack potion = potion1.clone();
+        potion.setAmount(1);
 
         PotionMeta potionMeta = (PotionMeta) potion1.getItemMeta();
         PotionMeta potion2Meta = (PotionMeta) potion2.getItemMeta();


### PR DESCRIPTION
Fixed some lores and now your machines will drop the items in input/output slots when you break them