### PR TITLE
[CI Skip] Fix JitPack builds

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+before_install:
+  - sdk install java 17.0.1-open
+  - sdk use java 17.0.1-open
+
+jdk:
+  - openjdk17

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.1-SNAPSHOT</version>
+                <version>3.3.0</version>
                 <configuration>
                     <relocations>
                         <relocation>


### PR DESCRIPTION
Changes `pom.xml` to use a non-snapshot version of the shade plugin and add `jitpack.yml` so FoxyMachines builds properly on JitPack