### PR TITLE
Improve feedback message when player's GPS complexity is not high enough

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-31</version>
+            <version>RC-32</version>
             <scope>provided</scope>
         </dependency>
 
@@ -148,5 +148,3 @@
         </dependency>
     </dependencies>
 </project>
-
-

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoaderListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoaderListener.java
@@ -42,12 +42,9 @@ public class ChunkLoaderListener implements Listener {
 
         NamespacedKey key = new NamespacedKey(FoxyMachines.getInstance(), "chunkloaders");
 
-        int i = 1;
-        if (p.getPersistentDataContainer().has(key, PersistentDataType.INTEGER)) {
-            i = p.getPersistentDataContainer().get(key, PersistentDataType.INTEGER) + 1;
-        }
+        int i = p.getPersistentDataContainer().getOrDefault(key, PersistentDataType.INTEGER, 0) + 1;
+        Config cfg = new Config(FoxyMachines.getInstance());
         if (!p.hasPermission("foxymachines.bypass-chunk-loader-limit")) {
-            Config cfg = new Config(FoxyMachines.getInstance());
             int max = cfg.getInt("max-chunk-loaders");
             if(max != 0 && max < i) {
                 p.sendMessage(ChatColor.LIGHT_PURPLE + "Maximum amount of chunk loaders already placed: " + max);
@@ -55,9 +52,10 @@ public class ChunkLoaderListener implements Listener {
                 return;
             }
         }
-
-        if (Slimefun.getGPSNetwork().getNetworkComplexity(p.getUniqueId()) < 7500*i) {
-            p.sendMessage(ChatColor.LIGHT_PURPLE + "Get more GPS Network Complexity to place more Chunk Loaders.");
+        int currentComplexity = Slimefun.getGPSNetwork().getNetworkComplexity(p.getUniqueId());
+        int requiredComplexity = cfg.getInt("gps-complexity-per-loader") * i;
+        if (currentComplexity < requiredComplexity) {
+            p.sendMessage(ChatColor.LIGHT_PURPLE + "You have " + currentComplexity + "/" + requiredComplexity + " GPS Network Complexity required to place another Chunk Loader.");
             e.setCancelled(true);
             return;
         }
@@ -67,4 +65,3 @@ public class ChunkLoaderListener implements Listener {
         BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
     }
 }
-

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,9 @@
 # max-chunk-loaders: default: 8
 # maximum amount of chunk loaders allowed per player, set to 0 for infinite.
 
+# gps-complexity-per-loader: default: 7500
+# the GPS complexity required for each chunk loader
+
 # ghost-blocks: default: true
 # Setting this to false will disable all Ghost Blocks without having to edit items.yml
 
@@ -9,5 +12,6 @@
 
 auto-update: true
 max-chunk-loaders: 8
+gps-complexity-per-loader: 7500
 ghost-blocks: true
 custom-mobs: true


### PR DESCRIPTION
I felt that the error message was not detailed enough, so I added the relevant numbers to help the player understand how much they need and how much they have. I also added a config option for the GPS complexity required per chunk loader, and had to update to RC-32 as RC-31 had been removed from the repository.