### PR TITLE
Add Fill Wand Config & AbstractWand improvements

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
+++ b/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
@@ -5,6 +5,7 @@ import io.github.mooy1.infinitylib.common.Scheduler;
 import io.github.mooy1.infinitylib.core.AbstractAddon;
 import io.github.mooy1.infinitylib.metrics.bukkit.Metrics;
 import lombok.SneakyThrows;
+import me.gallowsdove.foxymachines.abstracts.AbstractWand;
 import me.gallowsdove.foxymachines.abstracts.CustomBoss;
 import me.gallowsdove.foxymachines.commands.KillallCommand;
 import me.gallowsdove.foxymachines.commands.QuestCommand;
@@ -49,6 +50,7 @@ public class FoxyMachines extends AbstractAddon {
         Events.registerListener(new PositionSelectorListener());
 
         QuestUtils.init();
+        AbstractWand.init();
         ItemSetup.INSTANCE.init();
         ResearchSetup.INSTANCE.init();
 

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
@@ -1,17 +1,19 @@
 package me.gallowsdove.foxymachines.abstracts;
 
-import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
+import io.github.mooy1.infinitylib.core.AddonConfig;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.Rechargeable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
+import me.gallowsdove.foxymachines.utils.SimpleLocation;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.*;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -20,41 +22,52 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
+import java.util.logging.Level;
 
 public abstract class AbstractWand extends SlimefunItem implements NotPlaceable, Rechargeable {
-    public AbstractWand(SlimefunItemStack item, RecipeType recipeType, ItemStack [] recipe) {
-        super(Items.TOOLS_ITEM_GROUP, item, recipeType, recipe);
-    }
-
     private static final NamespacedKey MATERIAL_KEY = new NamespacedKey(FoxyMachines.getInstance(), "wand_material");
 
-    public static final Set<Material> BLACKLISTED = Set.of(Material.BARRIER, Material.SPAWNER, Material.COMMAND_BLOCK,
-            Material.STRUCTURE_BLOCK, Material.REPEATING_COMMAND_BLOCK, Material.CHAIN_COMMAND_BLOCK, Material.JIGSAW);
+    protected static final Set<Material> WHITELIST = new HashSet<>();
 
-    public static final Set<Material> WHITELISTED = new HashSet<>(List.of(Material.GLASS, Material.ACACIA_LEAVES,
-        Material.BIRCH_LEAVES, Material.DARK_OAK_LEAVES, Material.JUNGLE_LEAVES,
-        Material.OAK_LEAVES, Material.SPRUCE_LEAVES, Material.GRAY_STAINED_GLASS, Material.BLACK_STAINED_GLASS,
-        Material.BLUE_STAINED_GLASS, Material.BROWN_STAINED_GLASS, Material.CYAN_STAINED_GLASS, Material.GREEN_STAINED_GLASS,
-        Material.LIGHT_BLUE_STAINED_GLASS, Material.LIGHT_GRAY_STAINED_GLASS, Material.LIME_STAINED_GLASS, Material.MAGENTA_STAINED_GLASS,
-        Material.ORANGE_STAINED_GLASS, Material.PINK_STAINED_GLASS, Material.PURPLE_STAINED_GLASS, Material.RED_STAINED_GLASS,
-        Material.WHITE_STAINED_GLASS, Material.YELLOW_STAINED_GLASS));
+    protected static final Set<Material> BLACKLIST = new HashSet<>();
 
-    static {
-        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)) {
-            WHITELISTED.addAll(List.of(Material.AZALEA_LEAVES, Material.FLOWERING_AZALEA_LEAVES,
-                Material.TINTED_GLASS));
+    public static void init() {
+        if (!WHITELIST.isEmpty() || !BLACKLIST.isEmpty()) {
+            FoxyMachines.log(Level.WARNING, "Attempted to initialize AbstractWand after already initialized!");
+            return;
         }
-        if (Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_19)) {
-            WHITELISTED.add(Material.MANGROVE_LEAVES);
+
+        AddonConfig config = FoxyMachines.getInstance().getConfig();
+        loadList("fill-wand-white-list", WHITELIST, config.getStringList("fill-wand-white-list"));
+        loadList("fill-wand-black-list", BLACKLIST, config.getStringList("fill-wand-black-list"));
+    }
+
+    public static void loadList(String name, Set<Material> materials, List<String> values) {
+        for (String value : values) {
+            try {
+                Material material = Material.valueOf(value);
+                materials.add(material);
+                continue;
+            } catch (IllegalArgumentException ignored) {}
+
+            SlimefunTag tag = SlimefunTag.getTag(value);
+            if (tag == null) {
+                FoxyMachines.log(Level.WARNING, "Invalid Entry in \"" + name + "\": " + value);
+                continue;
+            }
+
+            materials.addAll(tag.getValues());
         }
     }
 
-    protected abstract float getCostPerBBlock();
-
-    protected abstract boolean isRemoving();
+    protected AbstractWand(SlimefunItemStack item, RecipeType recipeType, ItemStack [] recipe) {
+        super(Items.TOOLS_ITEM_GROUP, item, recipeType, recipe);
+    }
 
     @Override
     public void preRegister() {
@@ -69,21 +82,18 @@ public abstract class AbstractWand extends SlimefunItem implements NotPlaceable,
             ItemMeta meta = itemInInventory.getItemMeta();
             PersistentDataContainer container = meta.getPersistentDataContainer();
 
-            if (player.isSneaking()) {
-                if (!isRemoving() && e.getClickedBlock().isPresent()) {
+            if (player.isSneaking() && !isRemoving() && e.getClickedBlock().isPresent()) {
+                Material material = e.getClickedBlock().get().getType();
 
-                    Material material = e.getClickedBlock().get().getType();
-
-                    if ((material.isBlock() && material.isSolid() && material.isOccluding() && !AbstractWand.BLACKLISTED.contains(material)) ||
-                    AbstractWand.WHITELISTED.contains(material)) {
-                        player.sendMessage(ChatColor.LIGHT_PURPLE + "Material set to: " + material);
-                        container.set(AbstractWand.MATERIAL_KEY, PersistentDataType.STRING, material.toString());
-                        List<String> lore = this.getItem().getItemMeta().getLore();
-                        lore.set(lore.size() - 2, ChatColor.GRAY + "Material: " + ChatColor.YELLOW + material);
-                        meta.setLore(lore);
-                        itemInInventory.setItemMeta(meta);
-                        setItemCharge(itemInInventory, getItemCharge(itemInInventory)); // To update it in lore
-                    }
+                if ((material.isBlock() && material.isSolid() && material.isOccluding() && !BLACKLIST.contains(material)) ||
+                        WHITELIST.contains(material)) {
+                    player.sendMessage(ChatColor.LIGHT_PURPLE + "Material set to: " + material);
+                    container.set(AbstractWand.MATERIAL_KEY, PersistentDataType.STRING, material.toString());
+                    List<String> lore = this.getItem().getItemMeta().getLore();
+                    lore.set(lore.size() - 2, ChatColor.GRAY + "Material: " + ChatColor.YELLOW + material);
+                    meta.setLore(lore);
+                    itemInInventory.setItemMeta(meta);
+                    setItemCharge(itemInInventory, getItemCharge(itemInInventory)); // To update it in lore
                 }
             } else {
                 if (isRemoving() && !container.has(MATERIAL_KEY, PersistentDataType.STRING)) {
@@ -106,14 +116,14 @@ public abstract class AbstractWand extends SlimefunItem implements NotPlaceable,
                 ItemStack blocks = new ItemStack(material, locs.size());
 
                 if (isRemoving() || inventory.containsAtLeast(blocks, locs.size())) {
-                    if (removeItemCharge(e.getItem(),getCostPerBBlock() * locs.size())) {
+                    if (removeItemCharge(e.getItem(), getCostPerBlock() * locs.size())) {
                         inventory.removeItem(blocks);
                         for (Location loc : locs) {
                             Bukkit.getScheduler().runTask(FoxyMachines.getInstance(), () -> loc.getBlock().setType(material));
                         }
                     } else {
                         player.sendMessage(ChatColor.RED + "Your item doesn't have enough energy for that!");
-                        player.sendMessage(ChatColor.RED + "Energy needed: " + getCostPerBBlock() * locs.size());
+                        player.sendMessage(ChatColor.RED + "Energy needed: " + getCostPerBlock() * locs.size());
                     }
                 } else {
                     player.sendMessage(ChatColor.RED + "There aren't enough materials in your inventory!");
@@ -123,5 +133,70 @@ public abstract class AbstractWand extends SlimefunItem implements NotPlaceable,
         };
     }
 
-    protected abstract List<Location> getLocations(@Nonnull Player player);
+    protected List<Location> getLocations(@Nonnull Player player) {
+        List<Location> locs = new ArrayList<>();
+        PersistentDataContainer container = player.getPersistentDataContainer();
+        SimpleLocation loc1 = SimpleLocation.fromPersistentStorage(container, "primary_position");
+        SimpleLocation loc2 = SimpleLocation.fromPersistentStorage(container, "secondary_position");
+
+        if (loc1 == null || loc2 == null || !loc1.getWorldUUID().equals(loc2.getWorldUUID())) {
+            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
+            return locs;
+        }
+
+        if (loc1.getX() < loc2.getX()) {
+            int tmp = loc1.getX();
+            loc1.setX(loc2.getX());
+            loc2.setX(tmp);
+        }
+
+        if (loc1.getY() < loc2.getY()) {
+            int tmp = loc1.getY();
+            loc1.setY(loc2.getY());
+            loc2.setY(tmp);
+        }
+
+        if (loc1.getZ() < loc2.getZ()) {
+            int tmp = loc1.getZ();
+            loc1.setZ(loc2.getZ());
+            loc2.setZ(tmp);
+        }
+
+        if ((loc1.getX() - loc2.getX()) * (loc1.getY() - loc2.getY()) * (loc1.getZ() - loc2.getZ()) > getMaxBlocks()) {
+            player.sendMessage(ChatColor.RED + "Selected area is too big!");
+            return locs;
+        }
+
+        World world = Bukkit.getWorld(UUID.fromString(loc1.getWorldUUID()));
+
+        if (world == null) {
+            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
+            return locs;
+        }
+
+        for (int x = loc2.getX(); x <= loc1.getX(); x++) {
+            for (int y = loc2.getY(); y <= loc1.getY(); y++) {
+                for (int z = loc2.getZ(); z <= loc1.getZ(); z++) {
+                    Block block = world.getBlockAt(x, y, z);
+                    if (blockPredicate(player, block)) {
+                        locs.add(block.getLocation());
+                    }
+                }
+            }
+        }
+
+        if (locs.isEmpty()) {
+            player.sendMessage(ChatColor.RED + "No valid locations found given the selected points!");
+        }
+
+        return locs;
+    }
+
+    protected abstract int getMaxBlocks();
+
+    protected abstract boolean isRemoving();
+
+    protected abstract float getCostPerBlock();
+
+    protected abstract boolean blockPredicate(Player player, Block block);
 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/tools/FillWand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/tools/FillWand.java
@@ -3,25 +3,13 @@ package me.gallowsdove.foxymachines.implementation.tools;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.config.Config;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.abstracts.AbstractWand;
-import me.gallowsdove.foxymachines.utils.SimpleLocation;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.persistence.PersistentDataContainer;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 public class FillWand extends AbstractWand {
     public FillWand() {
@@ -33,71 +21,21 @@ public class FillWand extends AbstractWand {
     }
 
     @Override
+    protected int getMaxBlocks() {
+        return FoxyMachines.getInstance().getConfig().getInt("max-fill-wand-blocks");
+    }
+
+    @Override
     protected boolean isRemoving() {return false;}
 
     @Override
-    protected float getCostPerBBlock() {
+    protected float getCostPerBlock() {
         return 0.4F;
     }
 
     @Override
-    protected List<Location> getLocations(@Nonnull Player player) {
-        ArrayList<Location> locs = new ArrayList<>();
-        PersistentDataContainer container = player.getPersistentDataContainer();
-        SimpleLocation loc1 = SimpleLocation.fromPersistentStorage(container, "primary_position");
-        SimpleLocation loc2 = SimpleLocation.fromPersistentStorage(container, "secondary_position");
-
-        if (loc1 == null || loc2 == null || !loc1.getWorldUUID().equals(loc2.getWorldUUID())) {
-            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
-            return locs;
-        }
-
-        if (loc1.getX() < loc2.getX()) {
-            int tmp = loc1.getX();
-            loc1.setX(loc2.getX());
-            loc2.setX(tmp);
-        }
-
-        if (loc1.getY() < loc2.getY()) {
-            int tmp = loc1.getY();
-            loc1.setY(loc2.getY());
-            loc2.setY(tmp);
-        }
-
-        if (loc1.getZ() < loc2.getZ()) {
-            int tmp = loc1.getZ();
-            loc1.setZ(loc2.getZ());
-            loc2.setZ(tmp);
-        }
-
-        int max = new Config(FoxyMachines.getInstance()).getInt("max-fill-wand-blocks");
-        if ((loc1.getX() - loc2.getX()) * (loc1.getY() - loc2.getY()) * (loc1.getZ() - loc2.getZ()) > max) {
-            player.sendMessage(ChatColor.RED + "Selected area is too big!");
-            return locs;
-        }
-
-        World world = Bukkit.getWorld(UUID.fromString(loc1.getWorldUUID()));
-
-        if (world == null) {
-            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
-            return locs;
-        }
-
-        for (int x = loc2.getX(); x <= loc1.getX(); x++) {
-            for (int y = loc2.getY(); y <= loc1.getY(); y++) {
-                for (int z = loc2.getZ(); z <= loc1.getZ(); z++) {
-                    Block block = world.getBlockAt(x, y, z);
-                    if (block.getType().isAir() && Slimefun.getProtectionManager().hasPermission(player, block, Interaction.PLACE_BLOCK)) {
-                        locs.add(block.getLocation());
-                    }
-                }
-            }
-        }
-        if (locs.isEmpty()) {
-            player.sendMessage(ChatColor.RED + "No valid locations found given the selected points!");
-        }
-
-        return locs;
+    protected boolean blockPredicate(Player player, Block block) {
+        return block.getType().isAir() && Slimefun.getProtectionManager().hasPermission(player, block, Interaction.PLACE_BLOCK);
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/tools/SpongeWand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/tools/SpongeWand.java
@@ -30,72 +30,21 @@ public class SpongeWand extends AbstractWand {
     }
 
     @Override
+    protected int getMaxBlocks() {
+        return FoxyMachines.getInstance().getConfig().getInt("max-sponge-wand-blocks");
+    }
+
+    @Override
     protected boolean isRemoving() {return true;}
 
     @Override
-    protected float getCostPerBBlock() {
+    protected float getCostPerBlock() {
         return 0.24F;
     }
 
     @Override
-    protected List<Location> getLocations(@Nonnull Player player) {
-        ArrayList<Location> locs = new ArrayList<>();
-        PersistentDataContainer container = player.getPersistentDataContainer();
-        SimpleLocation loc1 = SimpleLocation.fromPersistentStorage(container, "primary_position");
-        SimpleLocation loc2 = SimpleLocation.fromPersistentStorage(container, "secondary_position");
-
-        if (loc1 == null || loc2 == null || !loc1.getWorldUUID().equals(loc2.getWorldUUID())) {
-            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
-            return locs;
-        }
-
-        if (loc1.getX() < loc2.getX()) {
-            int tmp = loc1.getX();
-            loc1.setX(loc2.getX());
-            loc2.setX(tmp);
-        }
-
-        if (loc1.getY() < loc2.getY()) {
-            int tmp = loc1.getY();
-            loc1.setY(loc2.getY());
-            loc2.setY(tmp);
-        }
-
-        if (loc1.getZ() < loc2.getZ()) {
-            int tmp = loc1.getZ();
-            loc1.setZ(loc2.getZ());
-            loc2.setZ(tmp);
-        }
-
-        int max = new Config(FoxyMachines.getInstance()).getInt("max-sponge-wand-blocks");
-        if ((loc1.getX() - loc2.getX()) * (loc1.getY() - loc2.getY()) * (loc1.getZ() - loc2.getZ()) > max) {
-            player.sendMessage(ChatColor.RED + "Selected area is too big!");
-            return locs;
-        }
-
-        World world = Bukkit.getWorld(UUID.fromString(loc1.getWorldUUID()));
-
-        if (world == null) {
-            player.sendMessage(ChatColor.RED + "Please select both locations using Position Selector!");
-            return locs;
-        }
-
-        for (int x = loc2.getX(); x <= loc1.getX(); x++) {
-            for (int y = loc2.getY(); y <= loc1.getY(); y++) {
-                for (int z = loc2.getZ(); z <= loc1.getZ(); z++) {
-                    Block block = world.getBlockAt(x, y, z);
-                    if ((block.getType() == Material.WATER || block.getType() == Material.LAVA) &&
-                            Slimefun.getProtectionManager().hasPermission(player, block, Interaction.BREAK_BLOCK)) {
-                        locs.add(block.getLocation());
-                    }
-                }
-            }
-        }
-        if (locs.isEmpty()) {
-            player.sendMessage(ChatColor.RED + "No valid locations found given the selected points!");
-        }
-
-        return locs;
+    protected boolean blockPredicate(Player player, Block block) {
+        return block.isLiquid() && Slimefun.getProtectionManager().hasPermission(player, block, Interaction.BREAK_BLOCK);
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/utils/QuestUtils.java
+++ b/src/main/java/me/gallowsdove/foxymachines/utils/QuestUtils.java
@@ -55,6 +55,7 @@ public class QuestUtils {
     public static void init() {
         if (!QUEST_MOBS.isEmpty()) {
             FoxyMachines.log(Level.WARNING, "Attempted to initialize QuestUtils after already initialized!");
+            return;
         }
 
         for (String questMob : FoxyMachines.getInstance().getConfig().getStringList("quest-mobs")) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -20,8 +20,11 @@
 # fill-wand-black-list
 # Materials/Tags the fill wand cannot place, the fill wand, automatically allows specific blocks, this is for any special cases
 
-# For materials see: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
-# For tags see: https://slimefun.github.io/javadocs/Slimefun4/docs/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.html
+# For materials see:
+#   - https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
+# For tags see:
+#   - https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Tag.html
+#   - https://slimefun.github.io/javadocs/Slimefun4/docs/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.html
 # If a material and tag share the same name only the material will be added.
 
 # max-sponge-wand-blocks: default: 16384

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,8 +1,8 @@
 # max-chunk-loaders: default: 8
-# maximum amount of chunk loaders allowed per player, set to 0 for infinite.
+# Maximum amount of chunk loaders allowed per player, set to 0 for infinite.
 
 # gps-complexity-per-loader: default: 7500
-# the GPS complexity required for each chunk loader
+# The GPS complexity required for each chunk loader
 
 # ghost-blocks: default: true
 # Setting this to false will disable all Ghost Blocks without having to edit items.yml
@@ -11,13 +11,24 @@
 # Setting this to false will disable all custom mobs and bosses. Some recipes will be altered and some items will be removed.
 
 # max-fill-wand-blocks: default: 4096
-# the max volume that can be filled at once
+# The max volume that can be filled at once
+
+# fill-wand-white-list
+# Materials/Tags the fill wand can place, the fill wand automatically allows specific blocks, this is for any special cases
+# Has higher priority over fill-wand-black-list
+
+# fill-wand-black-list
+# Materials/Tags the fill wand cannot place, the fill wand, automatically allows specific blocks, this is for any special cases
+
+# For materials see: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
+# For tags see: https://slimefun.github.io/javadocs/Slimefun4/docs/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.html
+# If a material and tag share the same name only the material will be added.
 
 # max-sponge-wand-blocks: default: 16384
-# the max volume that can be cleared at once
+# The max volume that can be cleared at once
 
 # quest-mobs
-# all mob types that can be required for a quest, for a full list of them go to: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
+# All mob types that can be required for a quest, for a full list of them go to: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
 
 auto-update: true
 max-chunk-loaders: 8
@@ -25,6 +36,15 @@ gps-complexity-per-loader: 7500
 ghost-blocks: true
 custom-mobs: true
 max-fill-wand-blocks: 4096
+fill-wand-white-list:
+  - LEAVES
+  - GLASS_BLOCKS
+fill-wand-black-list:
+  - BARRIER
+  - SPAWNER
+  - COMMAND_BLOCKS
+  - STRUCTURE_BLOCK
+  - JIGSAW
 max-sponge-wand-blocks: 16384
 quest-mobs:
   - BAT

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,35 +1,35 @@
 # max-chunk-loaders: default: 8
 # Maximum amount of chunk loaders allowed per player, set to 0 for infinite.
-
+#
 # gps-complexity-per-loader: default: 7500
 # The GPS complexity required for each chunk loader
-
+#
 # ghost-blocks: default: true
 # Setting this to false will disable all Ghost Blocks without having to edit items.yml
-
+#
 # custom-mobs:
 # Setting this to false will disable all custom mobs and bosses. Some recipes will be altered and some items will be removed.
-
+#
 # max-fill-wand-blocks: default: 4096
 # The max volume that can be filled at once
-
+#
 # fill-wand-white-list
 # Materials/Tags the fill wand can place, the fill wand automatically allows specific blocks, this is for any special cases
 # Has higher priority over fill-wand-black-list
-
+#
 # fill-wand-black-list
 # Materials/Tags the fill wand cannot place, the fill wand, automatically allows specific blocks, this is for any special cases
-
+#
 # For materials see:
 #   - https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Material.html
 # For tags see:
 #   - https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Tag.html
 #   - https://slimefun.github.io/javadocs/Slimefun4/docs/io/github/thebusybiscuit/slimefun4/utils/tags/SlimefunTag.html
 # If a material and tag share the same name only the material will be added.
-
+#
 # max-sponge-wand-blocks: default: 16384
 # The max volume that can be cleared at once
-
+#
 # quest-mobs
 # All mob types that can be required for a quest, for a full list of them go to: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
 


### PR DESCRIPTION
This PR aims to make the blocks a fill wand can be used with configurable & abstract some more code from SpongeWand and Fill Wand.

There are also a couple of small misc changes:
- Renames `AbstractWand#getCostPerBBlock` to `AbstractWand#getCostPerBlock` as I think that was a typo? If not ill remove the change.
- Humanizes the Material that is displayed to the player in both messages and lore, "GRASS_BLOCK" -> "Grass Block"
- Send a message that a material is not supported when trying to set the AbstractWands material to an unsupported material
- Making the config comment capitalization consistent
- Replacing the empty lines between comments with `#` to preserve the empty line when the config is actually generated.
- Adding `return` after the warning in QuestUtils as I missed that when making that PR

I have not tested the changes yet ill send a message here when I do 👍 