### PR TITLE
Rewrite the Sword Listener & Custom Swords

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/Items.java
+++ b/src/main/java/me/gallowsdove/foxymachines/Items.java
@@ -422,6 +422,7 @@ public final class Items{
             Material.NETHERITE_SWORD,
             "&cCursed Sword",
             "&7Life Steal I",
+            "&7Armor Ignorance I",
             "",
             "&7Confuses enemies. Increases damage.",
             "&7Can negatively affect wielder."
@@ -432,8 +433,7 @@ public final class Items{
             Material.NETHERITE_SWORD,
             "&eCelestial Sword",
             "&7Divine Smite II",
-            "",
-            "&7Ignores 20% of Resistances."
+            "&7Armor Ignorance III"
     );
 
     public static final SlimefunItemStack ELUCIDATOR = new SlimefunItemStack(
@@ -442,6 +442,7 @@ public final class Items{
             "&bElucidator",
             "&7Damage III",
             "&7Life Steal II",
+            "&7Armor Ignorance I",
             "&7Overheal"
     );
     static {

--- a/src/main/java/me/gallowsdove/foxymachines/Items.java
+++ b/src/main/java/me/gallowsdove/foxymachines/Items.java
@@ -422,7 +422,7 @@ public final class Items{
             Material.NETHERITE_SWORD,
             "&cCursed Sword",
             "&7Life Steal I",
-            "&7Armor Ignorance I",
+            "&7Armor Penetration I",
             "",
             "&7Confuses enemies. Increases damage.",
             "&7Can negatively affect wielder."
@@ -433,7 +433,7 @@ public final class Items{
             Material.NETHERITE_SWORD,
             "&eCelestial Sword",
             "&7Divine Smite II",
-            "&7Armor Ignorance III"
+            "&7Armor Penetration V"
     );
 
     public static final SlimefunItemStack ELUCIDATOR = new SlimefunItemStack(
@@ -442,7 +442,7 @@ public final class Items{
             "&bElucidator",
             "&7Damage III",
             "&7Life Steal II",
-            "&7Armor Ignorance I",
+            "&7Armor Penetration II",
             "&7Overheal"
     );
     static {

--- a/src/main/java/me/gallowsdove/foxymachines/Setup.java
+++ b/src/main/java/me/gallowsdove/foxymachines/Setup.java
@@ -38,6 +38,9 @@ import me.gallowsdove.foxymachines.implementation.tools.GhostBlockRemover;
 import me.gallowsdove.foxymachines.implementation.tools.PositionSelector;
 import me.gallowsdove.foxymachines.implementation.tools.RemoteController;
 import me.gallowsdove.foxymachines.implementation.tools.SpongeWand;
+import me.gallowsdove.foxymachines.implementation.weapons.CelestialSword;
+import me.gallowsdove.foxymachines.implementation.weapons.CursedSword;
+import me.gallowsdove.foxymachines.implementation.weapons.Elucidator;
 import me.gallowsdove.foxymachines.implementation.weapons.HealingBow;
 import me.gallowsdove.foxymachines.types.FoxyRecipeType;
 import org.bukkit.ChatColor;
@@ -297,42 +300,26 @@ final class ItemSetup {
         new ElectricFireStaff().register(FoxyMachines.getInstance());
         new ElectricFireStaffII().register(FoxyMachines.getInstance());
         new HealingBow().register(FoxyMachines.getInstance());
-        if (customMobs) {
-            new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ACRI_ARCUM, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
-                    Items.EQUANIMOUS_GEM, new ItemStack(Material.BOW), Items.EQUANIMOUS_GEM,
-                    Items.BUCKET_OF_BLOOD, Items.VILE_PUMPKIN, Items.BUCKET_OF_BLOOD,
-                    Items.EQUANIMOUS_GEM, new ItemStack(Material.BOW), Items.EQUANIMOUS_GEM
-                    }).register(FoxyMachines.getInstance());
-        } else {
-            new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ACRI_ARCUM, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
-                    Items.EQUANIMOUS_GEM, Items.DEMONIC_PLATE, Items.EQUANIMOUS_GEM,
-                    Items.BUCKET_OF_BLOOD, new ItemStack(Material.BOW), Items.BUCKET_OF_BLOOD,
-                    Items.EQUANIMOUS_GEM, Items.DEMONIC_PLATE, Items.EQUANIMOUS_GEM
-                    }).register(FoxyMachines.getInstance());
-        }
-        new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CURSED_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
+        new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ACRI_ARCUM, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
+                Items.EQUANIMOUS_GEM, customMobs ? new ItemStack(Material.BOW) : Items.DEMONIC_PLATE, Items.EQUANIMOUS_GEM,
+                Items.BUCKET_OF_BLOOD, customMobs ? Items.VILE_PUMPKIN : new ItemStack(Material.BOW), Items.BUCKET_OF_BLOOD,
+                Items.EQUANIMOUS_GEM, customMobs ? new ItemStack(Material.BOW) : Items.DEMONIC_PLATE, Items.EQUANIMOUS_GEM
+        }).register(FoxyMachines.getInstance());
+        new CursedSword(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CURSED_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
                 Items.BLOOD, Items.CURSED_RABBIT_PAW, Items.BLOOD,
                 Items.MAGIC_LUMP_5, new ItemStack(Material.NETHERITE_SWORD), Items.MAGIC_LUMP_5,
                 Items.BLOOD, Items.BLOOD_INFUSED_SKULL, Items.BLOOD
                 }).register(FoxyMachines.getInstance());
-        new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CELESTIAL_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
+        new CelestialSword(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CELESTIAL_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
                 Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5,
                 Items.PURE_BONE_DUST, new ItemStack(Material.NETHERITE_SWORD), Items.PURE_BONE_DUST,
                 Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5
                 }).register(FoxyMachines.getInstance());
-        if (customMobs) {
-            new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
-                    Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
-                    Items.BUCKET_OF_BLOOD, Items.PIXIE_QUEEN_HEART, Items.BUCKET_OF_BLOOD,
-                    Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
-                    }).register(FoxyMachines.getInstance());
-        } else {
-            new SlimefunItem(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
-                    Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
-                    Items.BUCKET_OF_BLOOD, Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
-                    Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
-                    }).register(FoxyMachines.getInstance());
-        }
+        new Elucidator(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
+                Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
+                Items.BUCKET_OF_BLOOD, customMobs ? Items.PIXIE_QUEEN_HEART : Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
+                Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
+        }).register(FoxyMachines.getInstance());
         new SlimefunArmorPiece(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.AQUATIC_HELMET, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
                 Items.EQUANIMOUS_GEM, Items.MAGIC_LUMP_5, Items.EQUANIMOUS_GEM,
                 Items.TROPICAL_FISH_SCALE, Items.AQUATIC_HELMET_FRAME, Items.TROPICAL_FISH_SCALE,

--- a/src/main/java/me/gallowsdove/foxymachines/Setup.java
+++ b/src/main/java/me/gallowsdove/foxymachines/Setup.java
@@ -305,21 +305,9 @@ final class ItemSetup {
                 Items.BUCKET_OF_BLOOD, customMobs ? Items.VILE_PUMPKIN : new ItemStack(Material.BOW), Items.BUCKET_OF_BLOOD,
                 Items.EQUANIMOUS_GEM, customMobs ? new ItemStack(Material.BOW) : Items.DEMONIC_PLATE, Items.EQUANIMOUS_GEM
         }).register(FoxyMachines.getInstance());
-        new CursedSword(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CURSED_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
-                Items.BLOOD, Items.CURSED_RABBIT_PAW, Items.BLOOD,
-                Items.MAGIC_LUMP_5, new ItemStack(Material.NETHERITE_SWORD), Items.MAGIC_LUMP_5,
-                Items.BLOOD, Items.BLOOD_INFUSED_SKULL, Items.BLOOD
-                }).register(FoxyMachines.getInstance());
-        new CelestialSword(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CELESTIAL_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
-                Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5,
-                Items.PURE_BONE_DUST, new ItemStack(Material.NETHERITE_SWORD), Items.PURE_BONE_DUST,
-                Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5
-                }).register(FoxyMachines.getInstance());
-        new Elucidator(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
-                Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
-                Items.BUCKET_OF_BLOOD, customMobs ? Items.PIXIE_QUEEN_HEART : Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
-                Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
-        }).register(FoxyMachines.getInstance());
+        new CursedSword().register(FoxyMachines.getInstance());
+        new CelestialSword().register(FoxyMachines.getInstance());
+        new Elucidator(customMobs).register(FoxyMachines.getInstance());
         new SlimefunArmorPiece(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.AQUATIC_HELMET, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
                 Items.EQUANIMOUS_GEM, Items.MAGIC_LUMP_5, Items.EQUANIMOUS_GEM,
                 Items.TROPICAL_FISH_SCALE, Items.AQUATIC_HELMET_FRAME, Items.TROPICAL_FISH_SCALE,

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
@@ -3,7 +3,9 @@ package me.gallowsdove.foxymachines.implementation.weapons;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
+import org.bukkit.Material;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -15,8 +17,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class CelestialSword extends OnHitWeapon {
-    public CelestialSword(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(itemGroup, item, recipeType, recipe);
+    public CelestialSword() {
+        super(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CELESTIAL_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
+                Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5,
+                Items.PURE_BONE_DUST, new ItemStack(Material.NETHERITE_SWORD), Items.PURE_BONE_DUST,
+                Items.MAGIC_LUMP_5, Items.POSEIDONS_BLESSING, Items.MAGIC_LUMP_5
+        });
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
@@ -1,0 +1,36 @@
+package me.gallowsdove.foxymachines.implementation.weapons;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.utils.Utils;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class CelestialSword extends OnHitWeapon {
+    public CelestialSword(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+        // Armor Ignorance III
+        Utils.dealDamageBypassingArmor(entity, (event.getDamage() - event.getFinalDamage()) * 0.16);
+
+        // Divine Smite II
+        if (random.nextInt(100) < 15) {
+            entity.getWorld().strikeLightningEffect(entity.getLocation());
+            entity.damage(8);
+        }
+
+        entity.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 80, 0, false, false));
+    }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CelestialSword.java
@@ -1,7 +1,5 @@
 package me.gallowsdove.foxymachines.implementation.weapons;
 
-import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
@@ -27,11 +25,12 @@ public class CelestialSword extends OnHitWeapon {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
-        // Armor Ignorance III
+    public void onHit(EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+        // Armor Penetration V
         Utils.dealDamageBypassingArmor(entity, (event.getDamage() - event.getFinalDamage()) * 0.16);
 
         // Divine Smite II
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         if (random.nextInt(100) < 15) {
             entity.getWorld().strikeLightningEffect(entity.getLocation());
             entity.damage(8);

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
@@ -3,7 +3,9 @@ package me.gallowsdove.foxymachines.implementation.weapons;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.HumanEntity;
@@ -24,8 +26,12 @@ public class CursedSword extends OnHitWeapon {
             new PotionEffect(PotionEffectType.CONFUSION, 100, 3, false, false),
             new PotionEffect(PotionEffectType.WITHER, 80, 1, false, false));
 
-    public CursedSword(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(itemGroup, item, recipeType, recipe);
+    public CursedSword() {
+        super(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.CURSED_SWORD, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
+                Items.BLOOD, Items.CURSED_RABBIT_PAW, Items.BLOOD,
+                Items.MAGIC_LUMP_5, new ItemStack(Material.NETHERITE_SWORD), Items.MAGIC_LUMP_5,
+                Items.BLOOD, Items.BLOOD_INFUSED_SKULL, Items.BLOOD
+        });
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
@@ -1,7 +1,5 @@
 package me.gallowsdove.foxymachines.implementation.weapons;
 
-import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
@@ -36,13 +34,13 @@ public class CursedSword extends OnHitWeapon {
 
     @Override
     @ParametersAreNonnullByDefault
-    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+    public void onHit(EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
         // Life Steal I
         double health = humanoid.getHealth() + 1.25D;
         double maxHealth = humanoid.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
         humanoid.setHealth(Math.min(health, maxHealth));
 
-        // Armor Ignorance I
+        // Armor Penetration I
         double damage = event.getDamage();
         double finalDamage = event.getFinalDamage();
         Utils.dealDamageBypassingArmor(entity, (damage - finalDamage) * 0.05);
@@ -54,6 +52,7 @@ public class CursedSword extends OnHitWeapon {
         entity.addPotionEffects(EFFECTS);
 
         // Particle Effects
+        ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = 0; i < 10; i++) {
             entity.getWorld().spawnParticle(Particle.SQUID_INK, entity.getLocation(), 1,
                     random.nextDouble(-1, 1), random.nextDouble(1.6, 2), random.nextDouble(-1, 1), 0);

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/CursedSword.java
@@ -1,0 +1,72 @@
+package me.gallowsdove.foxymachines.implementation.weapons;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.utils.Utils;
+import org.bukkit.Particle;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class CursedSword extends OnHitWeapon {
+    public static final List<PotionEffect> EFFECTS = List.of(
+            new PotionEffect(PotionEffectType.SLOW, 80, 1, false, false),
+            new PotionEffect(PotionEffectType.BLINDNESS, 80, 20, false, false),
+            new PotionEffect(PotionEffectType.CONFUSION, 100, 3, false, false),
+            new PotionEffect(PotionEffectType.WITHER, 80, 1, false, false));
+
+    public CursedSword(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+        // Life Steal I
+        double health = humanoid.getHealth() + 1.25D;
+        double maxHealth = humanoid.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+        humanoid.setHealth(Math.min(health, maxHealth));
+
+        // Armor Ignorance I
+        double damage = event.getDamage();
+        double finalDamage = event.getFinalDamage();
+        Utils.dealDamageBypassingArmor(entity, (damage - finalDamage) * 0.05);
+
+        // Increased Damage
+        event.setDamage(damage * 1.4);
+
+        // Negative Effects
+        entity.addPotionEffects(EFFECTS);
+
+        // Particle Effects
+        for (int i = 0; i < 10; i++) {
+            entity.getWorld().spawnParticle(Particle.SQUID_INK, entity.getLocation(), 1,
+                    random.nextDouble(-1, 1), random.nextDouble(1.6, 2), random.nextDouble(-1, 1), 0);
+        }
+
+        // Low Chance of Afflicting the User
+        if (random.nextInt(1000) < 25) {
+            int result = random.nextInt(100);
+            if (result < 20) {
+                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 40, 10, false, false));
+            } else if (result < 40) {
+                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 10, false, false));
+            } else if (result < 60) {
+                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 80, 2, false, false));
+            } else if (result < 80) {
+                humanoid.damage(event.getDamage() / 2);
+            } else {
+                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 150, 2, false, false));
+            }
+        }
+    }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
@@ -1,7 +1,5 @@
 package me.gallowsdove.foxymachines.implementation.weapons;
 
-import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
-import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
@@ -12,25 +10,24 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.concurrent.ThreadLocalRandom;
 
 public class Elucidator extends OnHitWeapon {
-    public Elucidator(boolean customMobs) {
+    public Elucidator(boolean customMobsEnabled) {
         super(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
                 Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
-                Items.BUCKET_OF_BLOOD, customMobs ? Items.PIXIE_QUEEN_HEART : Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
+                Items.BUCKET_OF_BLOOD, customMobsEnabled ? Items.PIXIE_QUEEN_HEART : Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
                 Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
         });
     }
 
     @Override
     @ParametersAreNonnullByDefault
-    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+    public void onHit(EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
         // Damage III
         event.setDamage(event.getDamage() * 2);
 
-        // Armor Ignorance I
-        Utils.dealDamageBypassingArmor(entity, (event.getDamage() - event.getFinalDamage()) * 0.05);
+        // Armor Penetration II
+        Utils.dealDamageBypassingArmor(entity, (event.getDamage() - event.getFinalDamage()) * 0.064);
 
         // Life Steal II && Overheal
         double health = humanoid.getHealth() + 1.5D;

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
@@ -1,0 +1,43 @@
+package me.gallowsdove.foxymachines.implementation.weapons;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.utils.Utils;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Elucidator extends OnHitWeapon {
+    public Elucidator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @Override
+    @ParametersAreNonnullByDefault
+    public void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity) {
+        // Damage III
+        event.setDamage(event.getDamage() * 2);
+
+        // Armor Ignorance I
+        Utils.dealDamageBypassingArmor(entity, (event.getDamage() - event.getFinalDamage()) * 0.05);
+
+        // Life Steal II && Overheal
+        double health = humanoid.getHealth() + 1.5D;
+        double maxHealth = humanoid.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
+
+        if (health > maxHealth) {
+            humanoid.setHealth(maxHealth);
+            if (humanoid.getAbsorptionAmount() < 12) {
+                humanoid.setAbsorptionAmount(Math.min(humanoid.getAbsorptionAmount() + (health - maxHealth) / 2, 12));
+            }
+        } else {
+            humanoid.setHealth(health);
+        }
+    }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/Elucidator.java
@@ -3,6 +3,7 @@ package me.gallowsdove.foxymachines.implementation.weapons;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.HumanEntity;
@@ -14,8 +15,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class Elucidator extends OnHitWeapon {
-    public Elucidator(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-        super(itemGroup, item, recipeType, recipe);
+    public Elucidator(boolean customMobs) {
+        super(Items.WEAPONS_AND_ARMORS_ITEM_GROUP, Items.ELUCIDATOR, RecipeType.ANCIENT_ALTAR, new ItemStack[]{
+                Items.EQUANIMOUS_GEM, Items.CURSED_SWORD, Items.EQUANIMOUS_GEM,
+                Items.BUCKET_OF_BLOOD, customMobs ? Items.PIXIE_QUEEN_HEART : Items.DEMONIC_PLATE, Items.BUCKET_OF_BLOOD,
+                Items.EQUANIMOUS_GEM, Items.CELESTIAL_SWORD, Items.EQUANIMOUS_GEM
+        });
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/OnHitWeapon.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/OnHitWeapon.java
@@ -1,0 +1,22 @@
+package me.gallowsdove.foxymachines.implementation.weapons;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.ThreadLocalRandom;
+
+public abstract class OnHitWeapon extends SlimefunItem {
+    protected OnHitWeapon(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+    }
+
+    @ParametersAreNonnullByDefault
+    public abstract void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity);
+}

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/OnHitWeapon.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/weapons/OnHitWeapon.java
@@ -10,7 +10,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class OnHitWeapon extends SlimefunItem {
     protected OnHitWeapon(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -18,5 +17,5 @@ public abstract class OnHitWeapon extends SlimefunItem {
     }
 
     @ParametersAreNonnullByDefault
-    public abstract void onHit(ThreadLocalRandom random, EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity);
+    public abstract void onHit(EntityDamageByEntityEvent event, HumanEntity humanoid, LivingEntity entity);
 }

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
@@ -3,14 +3,11 @@ package me.gallowsdove.foxymachines.listeners;
 import io.github.mooy1.infinitylib.common.Scheduler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
-import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.implementation.weapons.CelestialSword;
 import me.gallowsdove.foxymachines.implementation.weapons.CursedSword;
 import me.gallowsdove.foxymachines.implementation.weapons.OnHitWeapon;
 import me.gallowsdove.foxymachines.utils.QuestUtils;
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
@@ -23,8 +20,6 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-
-import java.util.concurrent.ThreadLocalRandom;
 
 public class SwordListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -40,10 +35,9 @@ public class SwordListener implements Listener {
             return;
         }
 
-        ThreadLocalRandom random = ThreadLocalRandom.current();
         ItemStack item = humanoid.getInventory().getItemInMainHand();
         if (SlimefunItem.getByItem(item) instanceof OnHitWeapon onHitWeapon) {
-            onHitWeapon.onHit(random, event, humanoid, entity);
+            onHitWeapon.onHit(event, humanoid, entity);
         }
     }
 

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
@@ -3,9 +3,13 @@ package me.gallowsdove.foxymachines.listeners;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
+import me.gallowsdove.foxymachines.implementation.weapons.CelestialSword;
+import me.gallowsdove.foxymachines.implementation.weapons.CursedSword;
 import me.gallowsdove.foxymachines.implementation.weapons.OnHitWeapon;
 import me.gallowsdove.foxymachines.utils.QuestUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
@@ -55,15 +59,16 @@ public class SwordListener implements Listener {
 
         QuestUtils.nextQuestLine(p);
         PlayerInventory inventory = p.getInventory();
+        SlimefunItem sfItem = SlimefunItem.getByItem(inventory.getItemInMainHand());
 
-        if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CURSED_SWORD, false, false)) {
+        if (sfItem instanceof CursedSword) {
             inventory.addItem(new SlimefunItemStack(Items.CURSED_SHARD, 1));
             p.sendMessage(ChatColor.RED + "The Cursed Sword is pleased.");
-            QuestUtils.sendQuestLine(p, Items.CURSED_SWORD);
-        } else if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CELESTIAL_SWORD, false, false)) {
+            Bukkit.getScheduler().runTaskLater(FoxyMachines.getInstance(), () -> QuestUtils.sendQuestLine(p, Items.CURSED_SWORD), 20L);
+        } else if (sfItem instanceof CelestialSword) {
             inventory.addItem(new SlimefunItemStack(Items.CELESTIAL_SHARD, 1));
             p.sendMessage(ChatColor.YELLOW + "The Celestial Sword is pleased.");
-            QuestUtils.sendQuestLine(p, Items.CELESTIAL_SWORD);
+            Bukkit.getScheduler().runTaskLater(FoxyMachines.getInstance(), () -> QuestUtils.sendQuestLine(p, Items.CELESTIAL_SWORD), 20L);
         }
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
@@ -1,13 +1,12 @@
 package me.gallowsdove.foxymachines.listeners;
 
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.gallowsdove.foxymachines.Items;
+import me.gallowsdove.foxymachines.implementation.weapons.OnHitWeapon;
 import me.gallowsdove.foxymachines.utils.QuestUtils;
-import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.ChatColor;
-import org.bukkit.Particle;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -19,111 +18,52 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 
-import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class SwordListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    private void onDamage(EntityDamageByEntityEvent e) {
-        if (e.getCause() == EntityDamageEvent.DamageCause.ENTITY_ATTACK || e.getCause() == EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK) {
-            if (e.getDamager() instanceof HumanEntity humanoid) {
-                ThreadLocalRandom random = ThreadLocalRandom.current();
-                ItemStack item = humanoid.getInventory().getItemInMainHand();
+    private void onDamage(EntityDamageByEntityEvent event) {
+        // If it's not a possible cause
+        if (event.getCause() != EntityDamageEvent.DamageCause.ENTITY_ATTACK && event.getCause() != EntityDamageEvent.DamageCause.ENTITY_SWEEP_ATTACK) {
+            return;
+        }
 
-                if (e.getEntity() instanceof LivingEntity entity) {
-                    if (SlimefunUtils.isItemSimilar(item, Items.CURSED_SWORD, false, false)) {
-                        ArrayList<PotionEffect> effects = new ArrayList<>();
+        // If the attacker is not a HumanEntity, someone who can't use the item, return
+        // Or if the attacked entity is not a living entity, someone who can't be attacked, return
+        if (!(event.getDamager() instanceof HumanEntity humanoid) || !(event.getEntity() instanceof LivingEntity entity)) {
+            return;
+        }
 
-                        effects.add(new PotionEffect(PotionEffectType.SLOW, 80, 1, false, false));
-                        effects.add(new PotionEffect(PotionEffectType.BLINDNESS, 80, 20, false, false));
-                        effects.add(new PotionEffect(PotionEffectType.CONFUSION, 100, 3, false, false));
-                        effects.add(new PotionEffect(PotionEffectType.WITHER, 80, 1, false, false));
-
-                        double health = humanoid.getHealth() + 1.25D;
-                        double maxHealth = humanoid.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
-                        humanoid.setHealth(Math.min(health, maxHealth));
-
-                        Utils.dealDamageBypassingArmor(entity, (e.getDamage() - e.getFinalDamage()) * 0.05);
-
-                        entity.addPotionEffects(effects);
-
-                        e.setDamage(e.getDamage() * 1.4);
-
-                        for (int i = 0; i < 10; i++) {
-                            entity.getWorld().spawnParticle(Particle.SQUID_INK, entity.getLocation(), 1,
-                                    random.nextDouble(-1, 1), random.nextDouble(1.6, 2), random.nextDouble(-1, 1), 0);
-                        }
-
-                        if (random.nextInt(1000) < 25) {
-                            int result = random.nextInt(100);
-                            if (result < 20) {
-                                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 40, 10, false, false));
-                            } else if (result < 40) {
-                                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 10, false, false));
-                            } else if (result < 60) {
-                                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 80, 2, false, false));
-                            } else if (result < 80) {
-                                humanoid.damage(e.getDamage() / 2);
-                            } else {
-                                humanoid.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 150, 2, false, false));
-                            }
-                        }
-                    } else if (SlimefunUtils.isItemSimilar(item, Items.CELESTIAL_SWORD, false, false)) {
-
-                        Utils.dealDamageBypassingArmor(entity, (e.getDamage() - e.getFinalDamage()) * 0.16);
-
-                        if (random.nextInt(100) < 15) {
-                            entity.getWorld().strikeLightningEffect(entity.getLocation());
-                            entity.damage(8);
-                        }
-
-                        entity.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, 80, 0, false, false));
-
-                    } else if (SlimefunUtils.isItemSimilar(item, Items.ELUCIDATOR, false, false)) {
-
-                        e.setDamage(e.getDamage() * 2);
-
-                        Utils.dealDamageBypassingArmor(entity, (e.getDamage() - e.getFinalDamage()) * 0.064);
-
-                        double health = humanoid.getHealth() + 1.5D;
-                        double maxHealth = humanoid.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue();
-
-                        if (health > maxHealth) {
-                            humanoid.setHealth(maxHealth);
-                            if (humanoid.getAbsorptionAmount() < 12) {
-                                humanoid.setAbsorptionAmount(Math.min(humanoid.getAbsorptionAmount() + (health - maxHealth) / 2, 12));
-                            }
-                        } else {
-                            humanoid.setHealth(health);
-                        }
-                    }
-                }
-            }
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        ItemStack item = humanoid.getInventory().getItemInMainHand();
+        if (SlimefunItem.getByItem(item) instanceof OnHitWeapon onHitWeapon) {
+            onHitWeapon.onHit(random, event, humanoid, entity);
         }
     }
 
     @EventHandler
     private void onSwordKill(EntityDeathEvent e) {
-        if (e.getEntity().getKiller() != null) {
-            Player p = e.getEntity().getKiller();
-            PlayerInventory inventory = p.getInventory();
+        if (e.getEntity().getKiller() == null) {
+            return;
+        }
 
-            if (!QuestUtils.hasActiveQuest(p) || !QuestUtils.isQuestEntity(p, e.getEntity())) {
-                return;
-            }
+        Player p = e.getEntity().getKiller();
+        if (!QuestUtils.hasActiveQuest(p) || !QuestUtils.isQuestEntity(p, e.getEntity())) {
+            return;
+        }
 
-            if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CURSED_SWORD, false, false)) {
-                inventory.addItem(new SlimefunItemStack(Items.CURSED_SHARD, 1));
-                p.sendMessage(ChatColor.RED + "The Cursed Sword is pleased.");
-            } else if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CELESTIAL_SWORD, false, false)) {
-                inventory.addItem(new SlimefunItemStack(Items.CELESTIAL_SHARD, 1));
-                p.sendMessage(ChatColor.YELLOW + "The Celestial Sword is pleased.");
-            }
+        QuestUtils.nextQuestLine(p);
+        PlayerInventory inventory = p.getInventory();
 
-            QuestUtils.nextQuestLine(p);
+        if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CURSED_SWORD, false, false)) {
+            inventory.addItem(new SlimefunItemStack(Items.CURSED_SHARD, 1));
+            p.sendMessage(ChatColor.RED + "The Cursed Sword is pleased.");
+            QuestUtils.sendQuestLine(p, Items.CURSED_SWORD);
+        } else if (SlimefunUtils.isItemSimilar(inventory.getItemInMainHand(), Items.CELESTIAL_SWORD, false, false)) {
+            inventory.addItem(new SlimefunItemStack(Items.CELESTIAL_SHARD, 1));
+            p.sendMessage(ChatColor.YELLOW + "The Celestial Sword is pleased.");
+            QuestUtils.sendQuestLine(p, Items.CELESTIAL_SWORD);
         }
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/SwordListener.java
@@ -1,5 +1,6 @@
 package me.gallowsdove.foxymachines.listeners;
 
+import io.github.mooy1.infinitylib.common.Scheduler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
@@ -64,11 +65,11 @@ public class SwordListener implements Listener {
         if (sfItem instanceof CursedSword) {
             inventory.addItem(new SlimefunItemStack(Items.CURSED_SHARD, 1));
             p.sendMessage(ChatColor.RED + "The Cursed Sword is pleased.");
-            Bukkit.getScheduler().runTaskLater(FoxyMachines.getInstance(), () -> QuestUtils.sendQuestLine(p, Items.CURSED_SWORD), 20L);
+            Scheduler.run(20, () -> QuestUtils.sendQuestLine(p, Items.CURSED_SWORD));
         } else if (sfItem instanceof CelestialSword) {
             inventory.addItem(new SlimefunItemStack(Items.CELESTIAL_SHARD, 1));
             p.sendMessage(ChatColor.YELLOW + "The Celestial Sword is pleased.");
-            Bukkit.getScheduler().runTaskLater(FoxyMachines.getInstance(), () -> QuestUtils.sendQuestLine(p, Items.CELESTIAL_SWORD), 20L);
+            Scheduler.run(20, () -> QuestUtils.sendQuestLine(p, Items.CELESTIAL_SWORD));
         }
     }
 }


### PR DESCRIPTION
What Changed:
- Added the Abstract class OnHitWeapon, this class extends SlimefunItem and has an abstract method onHit
  - This class is meant to be used for any weapons with on hit affects instead of having loads of else if clauses in the SwordListener
 - Added CursedSword, CelestialSword, and Elucidator, all extending OnHitWeapon
   - The code for each of the weapons was taken from SwordListener and cleaned up
   - The elucidator now has the same armor ignorance as the cursed sword for consistency with it now being a fake enchantment
 - Rewrote SwordListener to now use the OnHitWeapon class & just cleaned it up
   - It now uses SlimefunItem#getByItem + instanceof checks to avoid any issues with changed lore
   - When killing a mob with either the cursed or celestial sword it will now also tell the player the next entity to kill after 1 second, instead of only re assigning it without informing the player of the new assigned entity 
 - Changed the lore of all 3 swords to include Armor Ignorance, a new fake enchantment to represent the damage that ignores armor, previously the celestial sword said that it ignored 20% of resistance, the real number was 16% and this serves to replace that, I also added it to the other 2 swords as they did not contain any lore line about it even when they did damage that ignored armor
 - Switched the constructor calls to use a ternary operation for customMobs instead of a large if else statement to reduce code duplication

As of right now this PR is: **Tested, no issues found**