### PR TITLE
[Rewrite] Custom Mobs

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
+++ b/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
@@ -36,6 +36,7 @@ public class FoxyMachines extends AbstractAddon {
     public void enable() {
         instance = this;
 
+        Events.registerListener(new ChunkLoadListener());
         Events.registerListener(new ChunkLoaderListener());
         Events.registerListener(new BoostedRailListener());
         Events.registerListener(new BerryBushListener());

--- a/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
+++ b/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
@@ -8,6 +8,7 @@ import lombok.SneakyThrows;
 import me.gallowsdove.foxymachines.abstracts.AbstractWand;
 import me.gallowsdove.foxymachines.abstracts.CustomBoss;
 import me.gallowsdove.foxymachines.commands.KillallCommand;
+import me.gallowsdove.foxymachines.commands.ListallCommand;
 import me.gallowsdove.foxymachines.commands.QuestCommand;
 import me.gallowsdove.foxymachines.commands.SacrificialAltarCommand;
 import me.gallowsdove.foxymachines.commands.SummonCommand;
@@ -68,7 +69,7 @@ public class FoxyMachines extends AbstractAddon {
         new Metrics(this, 10568);
 
         getAddonCommand().addSub(new KillallCommand()).addSub((new QuestCommand())).
-                addSub(new SacrificialAltarCommand()).addSub(new SummonCommand());
+                addSub(new SacrificialAltarCommand()).addSub(new SummonCommand()).addSub(new ListallCommand());
     }
 
     @SneakyThrows

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomBoss.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomBoss.java
@@ -31,7 +31,7 @@ public abstract class CustomBoss extends CustomMob {
 
     private final Set<DamageCause> resistances;
 
-    public CustomBoss(@Nonnull String id, @Nonnull String name, @Nonnull EntityType type, int health, @Nonnull DamageCause... resistances) {
+    protected CustomBoss(@Nonnull String id, @Nonnull String name, @Nonnull EntityType type, int health, @Nonnull DamageCause... resistances) {
         super(id, name, type, health);
         this.resistances = Set.of(resistances);
     }
@@ -56,6 +56,14 @@ public abstract class CustomBoss extends CustomMob {
         spawned.setRemoveWhenFarAway(false);
 
         instances.put(spawned, bossbar);
+    }
+
+    @Override
+    @OverridingMethodsMustInvokeSuper
+    public void onMobTick(@Nonnull LivingEntity mob, int tick) {
+        if (tick == 100) {
+            onBossPattern(mob);
+        }
     }
 
     @Override
@@ -91,6 +99,8 @@ public abstract class CustomBoss extends CustomMob {
     @Override
     @OverridingMethodsMustInvokeSuper
     public void onDeath(@Nonnull EntityDeathEvent e) {
+        super.onDeath(e);
+
         BossBar bossbar = getBossBarForEntity(e.getEntity());
         bossbar.setVisible(false);
         bossbar.removeAll();

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomBoss.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomBoss.java
@@ -68,20 +68,20 @@ public abstract class CustomBoss extends CustomMob {
 
     @Override
     @OverridingMethodsMustInvokeSuper
-    public final void onHit(@Nonnull EntityDamageEvent e) {
-        this.onBossDamaged(e);
+    public final void onHit(@Nonnull EntityDamageEvent event) {
+        this.onBossDamaged(event);
 
-        if (!e.isCancelled() && e.getEntity() instanceof LivingEntity entity) {
+        if (!event.isCancelled() && event.getEntity() instanceof LivingEntity entity) {
             BossBar bossbar = getBossBarForEntity(entity);
 
             if (entity.isInsideVehicle() && entity.getVehicle() instanceof LivingEntity vehicle) {
-                double finalHealth = entity.getHealth() + vehicle.getHealth() - e.getFinalDamage();
+                double finalHealth = entity.getHealth() + vehicle.getHealth() - event.getFinalDamage();
                 if (finalHealth > 0) {
                     bossbar.setProgress(Math.min(finalHealth / (entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() +
                             vehicle.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()), 1));
                 }
             } else {
-                double finalHealth = entity.getHealth() - e.getFinalDamage();
+                double finalHealth = entity.getHealth() - event.getFinalDamage();
                 if (finalHealth > 0) {
                     bossbar.setProgress(Math.min(finalHealth / entity.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue(), 1));
                 }
@@ -98,10 +98,10 @@ public abstract class CustomBoss extends CustomMob {
 
     @Override
     @OverridingMethodsMustInvokeSuper
-    public void onDeath(@Nonnull EntityDeathEvent e) {
-        super.onDeath(e);
+    public void onDeath(@Nonnull EntityDeathEvent event) {
+        super.onDeath(event);
 
-        BossBar bossbar = getBossBarForEntity(e.getEntity());
+        BossBar bossbar = getBossBarForEntity(event.getEntity());
         bossbar.setVisible(false);
         bossbar.removeAll();
     }

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
@@ -8,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.libraries.commons.lang.Validate;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public abstract class CustomMob {
 
@@ -51,6 +53,7 @@ public abstract class CustomMob {
 
     private static final NamespacedKey KEY = new NamespacedKey(FoxyMachines.getInstance(), "mob");
 
+    @Getter
     @Nonnull
     private final String id;
     @Nonnull
@@ -118,15 +121,30 @@ public abstract class CustomMob {
     }
 
     public void cacheEntity(@Nonnull Entity entity) {
+        cacheEntity(entity.getUniqueId());
+    }
+
+    public void cacheEntity(@Nonnull UUID uuid) {
         Set<UUID> entities = MOB_CACHE.getOrDefault(this, new HashSet<>());
-        entities.add(entity.getUniqueId());
+        entities.add(uuid);
         MOB_CACHE.put(this, entities);
     }
 
     public void uncacheEntity(@Nonnull Entity entity) {
+        uncacheEntity(entity.getUniqueId());
+    }
+
+    public void uncacheEntity(@Nonnull UUID uuid) {
         Set<UUID> entities = MOB_CACHE.getOrDefault(this, new HashSet<>());
-        entities.remove(entity.getUniqueId());
+        entities.remove(uuid);
         MOB_CACHE.put(this, entities);
+    }
+
+    public static void debug() {
+        Bukkit.broadcastMessage("CACHE:");
+        for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
+            Bukkit.broadcastMessage(entry.getKey().getId() + " (" + entry.getValue().size() + ")\n" + entry.getValue().stream().map(UUID::toString).collect(Collectors.joining("\n")));
+        }
     }
 
     static {

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
@@ -96,22 +96,22 @@ public abstract class CustomMob {
 
     public void onMobTick(@Nonnull LivingEntity mob, int tick) { }
 
-    protected void onHit(@Nonnull EntityDamageEvent e) { }
+    protected void onHit(@Nonnull EntityDamageEvent event) { }
 
-    protected void onAttack(@Nonnull EntityDamageByEntityEvent e) { }
+    protected void onAttack(@Nonnull EntityDamageByEntityEvent event) { }
 
-    protected void onInteract(@Nonnull PlayerInteractEntityEvent e) { }
+    protected void onInteract(@Nonnull PlayerInteractEntityEvent event) { }
 
-    protected void onTarget(@Nonnull EntityTargetEvent e) { }
+    protected void onTarget(@Nonnull EntityTargetEvent event) { }
 
     @OverridingMethodsMustInvokeSuper
-    protected void onDeath(@Nonnull EntityDeathEvent e) {
-        uncacheEntity(e.getEntity());
+    protected void onDeath(@Nonnull EntityDeathEvent event) {
+        uncacheEntity(event.getEntity());
     }
 
-    protected void onCastSpell(EntitySpellCastEvent e) { }
+    protected void onCastSpell(@Nonnull EntitySpellCastEvent event) { }
 
-    protected void onDamage(EntityDamageEvent e) { }
+    protected void onDamage(@Nonnull EntityDamageEvent event) { }
 
     protected Vector getSpawnOffset() {
         return new Vector();
@@ -133,74 +133,74 @@ public abstract class CustomMob {
         Events.registerListener(new Listener() {
 
             @EventHandler
-            public void onTarget(@Nonnull EntityTargetEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getEntity());
+            public void onTarget(@Nonnull EntityTargetEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getEntity());
                 if (customMob != null) {
-                    customMob.onTarget(e);
+                    customMob.onTarget(event);
                 }
             }
 
             @EventHandler
-            public void onInteract(@Nonnull PlayerInteractEntityEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getRightClicked());
+            public void onInteract(@Nonnull PlayerInteractEntityEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getRightClicked());
                 if (customMob != null) {
-                    customMob.onInteract(e);
+                    customMob.onInteract(event);
                 }
             }
 
             @EventHandler
-            public void onHit(@Nonnull EntityDamageByEntityEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getDamager());
+            public void onHit(@Nonnull EntityDamageByEntityEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getDamager());
                 if (customMob != null) {
-                    customMob.onAttack(e);
+                    customMob.onAttack(event);
                 }
             }
 
             @EventHandler
-            public void onDamaged(@Nonnull EntityDamageEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getEntity());
+            public void onDamaged(@Nonnull EntityDamageEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getEntity());
                 if (customMob != null) {
-                    customMob.onHit(e);
+                    customMob.onHit(event);
                 }
             }
 
             @EventHandler
-            public void onDeath(@Nonnull EntityDeathEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getEntity());
+            public void onDeath(@Nonnull EntityDeathEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getEntity());
                 if (customMob != null) {
-                    customMob.onDeath(e);
+                    customMob.onDeath(event);
                 }
             }
 
             @EventHandler
-            public void onSpellCast(@Nonnull EntitySpellCastEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getEntity());
+            public void onSpellCast(@Nonnull EntitySpellCastEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getEntity());
                 if (customMob != null) {
-                    customMob.onCastSpell(e);
+                    customMob.onCastSpell(event);
                 }
             }
 
             @EventHandler
-            public void onDamage(@Nonnull EntityDamageEvent e) {
-                CustomMob customMob = CustomMob.getByEntity(e.getEntity());
+            public void onDamage(@Nonnull EntityDamageEvent event) {
+                CustomMob customMob = CustomMob.getByEntity(event.getEntity());
                 if (customMob != null) {
-                    customMob.onDamage(e);
+                    customMob.onDamage(event);
                 }
             }
 
             @EventHandler(ignoreCancelled = true)
-            private void onNametagEvent(PlayerInteractEntityEvent e) {
-                ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+            private void onNametagEvent(PlayerInteractEntityEvent event) {
+                ItemStack item = event.getPlayer().getInventory().getItemInMainHand();
 
-                if (item.getType() == Material.NAME_TAG && CustomMob.getByEntity(e.getRightClicked()) != null) {
-                    e.setCancelled(true);
+                if (item.getType() == Material.NAME_TAG && CustomMob.getByEntity(event.getRightClicked()) != null) {
+                    event.setCancelled(true);
                 }
             }
 
             @EventHandler(ignoreCancelled = true)
-            private void onCombust(EntityCombustEvent e) {
-                if (CustomMob.getByEntity(e.getEntity()) != null) {
-                    e.setCancelled(true);
+            private void onCombust(EntityCombustEvent event) {
+                if (CustomMob.getByEntity(event.getEntity()) != null) {
+                    event.setCancelled(true);
                 }
             }
         });

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/CustomMob.java
@@ -1,7 +1,6 @@
 package me.gallowsdove.foxymachines.abstracts;
 
 import io.github.mooy1.infinitylib.common.Events;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.ChunkPosition;
 import lombok.Getter;
 import me.gallowsdove.foxymachines.FoxyMachines;
 
@@ -9,7 +8,6 @@ import io.github.thebusybiscuit.slimefun4.libraries.commons.lang.Validate;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 
-import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -21,7 +19,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.*;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
 
@@ -39,18 +36,17 @@ import java.util.UUID;
 public abstract class CustomMob {
 
     public static final Map<String, CustomMob> MOBS = new HashMap<>();
-    public static final Set<ChunkPosition> SCANNED_CHUNKS = new HashSet<>();
     public static final Map<CustomMob, Set<UUID>> MOB_CACHE = new HashMap<>();
 
     @Nullable
-    public static CustomMob getByID(@Nonnull String id) {
+    public static CustomMob getById(@Nonnull String id) {
         return MOBS.get(id);
     }
 
     @Nullable
     public static CustomMob getByEntity(@Nonnull Entity entity) {
         String id = PersistentDataAPI.getString(entity, CustomMob.KEY);
-        return id == null ? null : getByID(id);
+        return id == null ? null : getById(id);
     }
 
     private static final NamespacedKey KEY = new NamespacedKey(FoxyMachines.getInstance(), "mob");
@@ -121,13 +117,13 @@ public abstract class CustomMob {
         return new Vector();
     }
 
-    protected void cacheEntity(@Nonnull Entity entity) {
+    public void cacheEntity(@Nonnull Entity entity) {
         Set<UUID> entities = MOB_CACHE.getOrDefault(this, new HashSet<>());
         entities.add(entity.getUniqueId());
         MOB_CACHE.put(this, entities);
     }
 
-    protected void uncacheEntity(@Nonnull Entity entity) {
+    public void uncacheEntity(@Nonnull Entity entity) {
         Set<UUID> entities = MOB_CACHE.getOrDefault(this, new HashSet<>());
         entities.remove(entity.getUniqueId());
         MOB_CACHE.put(this, entities);
@@ -135,23 +131,6 @@ public abstract class CustomMob {
 
     static {
         Events.registerListener(new Listener() {
-
-            @EventHandler
-            public void onChunkLoad(@Nonnull ChunkLoadEvent e) {
-                Chunk chunk = e.getChunk();
-                ChunkPosition chunkPosition = new ChunkPosition(chunk);
-                if (SCANNED_CHUNKS.contains(chunkPosition)) {
-                    return;
-                }
-                SCANNED_CHUNKS.add(chunkPosition);
-
-                for (Entity entity : chunk.getEntities()) {
-                    CustomMob customMob = getByEntity(entity);
-                    if (customMob != null) {
-                        customMob.cacheEntity(entity);
-                    }
-                }
-            }
 
             @EventHandler
             public void onTarget(@Nonnull EntityTargetEvent e) {

--- a/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
@@ -32,18 +32,25 @@ public class KillallCommand extends SubCommand {
             return;
         }
 
+        int i = 0;
         for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
             Set<UUID> entities = entry.getValue();
+            Set<UUID> newEntities = new HashSet<>();
             for (UUID uuid : new HashSet<>(entities)) {
                 Entity entity = Bukkit.getEntity(uuid);
                 if (entity != null && entity.getWorld().equals(player.getWorld())) {
+                    i++;
                     entity.remove();
-                    entities.remove(uuid);
+                    continue;
                 }
+                newEntities.add(uuid);
             }
+            entry.setValue(newEntities);
         }
 
         CustomBoss.removeBossBars();
+
+        player.sendMessage("Killed %s Entities".formatted(i));
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
@@ -7,7 +7,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
@@ -7,12 +7,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -32,25 +31,20 @@ public class KillallCommand extends SubCommand {
             return;
         }
 
-        int i = 0;
-        for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
-            Set<UUID> entities = entry.getValue();
-            Set<UUID> newEntities = new HashSet<>();
-            for (UUID uuid : new HashSet<>(entities)) {
+        int count = 0;
+        for (Set<UUID> uuids : CustomMob.MOB_CACHE.values()) {
+            for (UUID uuid : uuids) {
                 Entity entity = Bukkit.getEntity(uuid);
-                if (entity != null && entity.getWorld().equals(player.getWorld())) {
-                    i++;
+                if (entity instanceof LivingEntity && entity.getWorld().equals(player.getWorld())) {
                     entity.remove();
-                    continue;
+                    count++;
                 }
-                newEntities.add(uuid);
             }
-            entry.setValue(newEntities);
         }
 
         CustomBoss.removeBossBars();
 
-        player.sendMessage("Killed %s Entities".formatted(i));
+        player.sendMessage("Killed %s Entities".formatted(count));
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/KillallCommand.java
@@ -3,34 +3,44 @@ package me.gallowsdove.foxymachines.commands;
 import io.github.mooy1.infinitylib.commands.SubCommand;
 import me.gallowsdove.foxymachines.abstracts.CustomBoss;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nonnull;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 
 public class KillallCommand extends SubCommand {
     public KillallCommand() {
-        super("killall", "Kills all Custom Mobs from FoxyMachines.", "foxymachines.admin");
+        super("killall", "Kills all Custom Mobs from FoxyMachines in your current World.", "foxymachines.admin");
     }
 
     @Override
-    protected void execute(@Nonnull CommandSender commandSender, @Nonnull String[] args) {
-        if (!(commandSender instanceof Player p)) {
+    protected void execute(@Nonnull CommandSender sender, @Nonnull String[] args) {
+        if (!(sender instanceof Player player)) {
             return;
         }
 
         if (args.length != 0) {
-            commandSender.sendMessage(ChatColor.LIGHT_PURPLE + "Usage: /foxy killall");
+            sender.sendMessage(ChatColor.LIGHT_PURPLE + "Usage: /foxy killall");
             return;
         }
 
-        for (LivingEntity entity : p.getWorld().getLivingEntities()) {
-            CustomMob mob = CustomMob.getByEntity(entity);
-            if (mob != null) {
-                entity.remove();
+        for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
+            Set<UUID> entities = entry.getValue();
+            for (UUID uuid : new HashSet<>(entities)) {
+                Entity entity = Bukkit.getEntity(uuid);
+                if (entity != null && entity.getWorld().equals(player.getWorld())) {
+                    entity.remove();
+                    entities.remove(uuid);
+                }
             }
         }
 

--- a/src/main/java/me/gallowsdove/foxymachines/commands/ListallCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/ListallCommand.java
@@ -1,0 +1,28 @@
+package me.gallowsdove.foxymachines.commands;
+
+import io.github.mooy1.infinitylib.commands.SubCommand;
+import me.gallowsdove.foxymachines.abstracts.CustomMob;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public class ListallCommand extends SubCommand {
+    public ListallCommand() {
+        super("listall", "Lists all Custom Mobs from FoxyMachines", "foxymachines.admin");
+    }
+
+    @Override
+    protected void execute(@Nonnull CommandSender sender, @Nonnull String[] args) {
+        if (args.length != 0) {
+            sender.sendMessage(ChatColor.LIGHT_PURPLE + "Usage: /foxy listall");
+            return;
+        }
+
+        CustomMob.debug();
+    }
+
+    @Override
+    protected void complete(@Nonnull CommandSender commandSender, @Nonnull String[] strings, @Nonnull List<String> list) { }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/commands/SummonCommand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/commands/SummonCommand.java
@@ -16,26 +16,26 @@ public final class SummonCommand extends SubCommand {
     }
 
     @Override
-    protected void execute(@Nonnull CommandSender commandSender, @Nonnull String[] args) {
-        if (!(commandSender instanceof Player p)) {
+    protected void execute(@Nonnull CommandSender sender, @Nonnull String[] args) {
+        if (!(sender instanceof Player player)) {
             return;
         }
 
         if (args.length != 1) {
-            commandSender.sendMessage(ChatColor.LIGHT_PURPLE + "Usage: /foxy summon <MOB_ID>");
+            sender.sendMessage(ChatColor.LIGHT_PURPLE + "Usage: /foxy summon <MOB_ID>");
             return;
         }
 
-        CustomMob mob = CustomMob.getByID(args[0]);
+        CustomMob mob = CustomMob.getById(args[0]);
 
         if (mob != null) {
-            mob.spawn(p.getLocation());
+            mob.spawn(player.getLocation());
         }
     }
 
 
     @Override
-    protected void complete(@Nonnull CommandSender commandSender, @Nonnull String[] args, @Nonnull List<String> tabs) {
+    protected void complete(@Nonnull CommandSender sender, @Nonnull String[] args, @Nonnull List<String> tabs) {
         tabs.addAll(CustomMob.MOBS.keySet());
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/CustomMobSpawnEgg.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/CustomMobSpawnEgg.java
@@ -7,8 +7,8 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -17,14 +17,13 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 public class CustomMobSpawnEgg extends SimpleSlimefunItem<ItemUseHandler> {
 
-    String id;
-    SlimefunItemStack slimefunItem;
+    private final String id;
 
     @ParametersAreNonnullByDefault
     public CustomMobSpawnEgg(SubItemGroup itemGroup, String id, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
+
         this.id = id;
-        this.slimefunItem = item;
     }
 
     @Nonnull
@@ -32,11 +31,18 @@ public class CustomMobSpawnEgg extends SimpleSlimefunItem<ItemUseHandler> {
     public ItemUseHandler getItemHandler() {
         return e -> {
             e.cancel();
-            Player p = e.getPlayer();
-            if (Slimefun.getProtectionManager().hasPermission(e.getPlayer(), p.getLocation(), Interaction.ATTACK_PLAYER)) {
-                ItemStack item = SlimefunUtils.isItemSimilar(p.getInventory().getItemInMainHand(), slimefunItem, false, false) ? p.getInventory().getItemInMainHand() : p.getInventory().getItemInOffHand();
-                item.setAmount(item.getAmount() - 1);
-                CustomMob.getByID(id).spawn(e.getPlayer().getLocation());
+            Player player = e.getPlayer();
+            Location location = player.getLocation();
+            if (!Slimefun.getProtectionManager().hasPermission(player, location, Interaction.ATTACK_PLAYER)) {
+                return;
+            }
+
+            ItemStack item = e.getItem();
+            item.setAmount(item.getAmount() - 1);
+
+            CustomMob mob = CustomMob.getById(this.id);
+            if (mob != null) {
+                mob.spawn(e.getPlayer().getLocation());
             }
         };
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/CustomMobSpawnEgg.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/CustomMobSpawnEgg.java
@@ -8,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -29,20 +30,22 @@ public class CustomMobSpawnEgg extends SimpleSlimefunItem<ItemUseHandler> {
     @Nonnull
     @Override
     public ItemUseHandler getItemHandler() {
-        return e -> {
-            e.cancel();
-            Player player = e.getPlayer();
+        return event -> {
+            event.cancel();
+            Player player = event.getPlayer();
             Location location = player.getLocation();
             if (!Slimefun.getProtectionManager().hasPermission(player, location, Interaction.ATTACK_PLAYER)) {
                 return;
             }
 
-            ItemStack item = e.getItem();
-            item.setAmount(item.getAmount() - 1);
+            ItemStack item = event.getItem();
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                item.setAmount(item.getAmount() - 1);
+            }
 
             CustomMob mob = CustomMob.getById(this.id);
             if (mob != null) {
-                mob.spawn(e.getPlayer().getLocation());
+                mob.spawn(event.getPlayer().getLocation());
             }
         };
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
@@ -50,7 +50,7 @@ public class HeadlessHorseman extends CustomBoss {
 
         spawned.setInvisible(true);
 
-        CustomMob mob = CustomMob.getByID("SKELETON_HORSE");
+        CustomMob mob = CustomMob.getById("SKELETON_HORSE");
         SkeletonHorse horse = (SkeletonHorse) mob.spawn(spawned.getLocation());
         horse.addPassenger(spawned);
 
@@ -190,7 +190,7 @@ public class HeadlessHorseman extends CustomBoss {
     }
 
     private void spawnHelldogs(Location loc) {
-        CustomMob helldog = CustomMob.getByID("HELLDOG");
+        CustomMob helldog = CustomMob.getById("HELLDOG");
         if (helldog == null) {
             FoxyMachines.getInstance().getLogger().warning("Could not spawn Helldogs! Please report this to the github!");
             return;

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
@@ -24,7 +24,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.util.NumberConversions;
 
 import javax.annotation.Nonnull;
 import java.util.concurrent.ThreadLocalRandom;
@@ -98,7 +97,7 @@ public class HeadlessHorseman extends CustomBoss {
             pattern = AttackPattern.SUMMON;
         }
 
-        mob.getPersistentDataContainer().set(PATTERN_KEY, PersistentDataType.SHORT, pattern);
+        PersistentDataAPI.setShort(mob, PATTERN_KEY, pattern);
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
@@ -138,10 +138,13 @@ public class HeadlessHorseman extends CustomBoss {
             arrow.setGlowing(true);
             arrow.setSilent(true);
             arrow.setGravity(false);
+            arrow.setPersistent(false);
             try {
                 // TODO: Find out why this sometimes throws an error
                 arrow.setVelocity(target.getLocation().toVector().subtract(headlessHorseman.getLocation().toVector()).normalize().multiply(1.64));
-            } catch (IllegalArgumentException ignored) {}
+            } catch (IllegalArgumentException ignored) {
+                arrow.remove();
+            }
             return;
         }
 

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/HeadlessHorseman.java
@@ -2,6 +2,7 @@ package me.gallowsdove.foxymachines.implementation.mobs;
 
 import io.github.mooy1.infinitylib.common.Scheduler;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.abstracts.CustomBoss;
@@ -115,15 +116,10 @@ public class HeadlessHorseman extends CustomBoss {
         super.onMobTick(entity, tick);
 
         Skeleton headlessHorseman = (Skeleton) entity;
-        short pattern = entity.getPersistentDataContainer().get(PATTERN_KEY, PersistentDataType.SHORT);
+        short pattern = PersistentDataAPI.getShort(entity, PATTERN_KEY);
 
         if ((tick + 4) % 5 == 0) {
-            LivingEntity target = headlessHorseman.getTarget();
-            Location location = headlessHorseman.getLocation();
-            if (!(target instanceof Player) || !Utils.isWithinBox(location, target.getLocation(), 30, 20, 30)) {
-                Player player = Utils.getNearbyPlayerInSurvival(location, 30, 20, 30);
-                headlessHorseman.setTarget(player);
-            }
+            headlessHorseman.setTarget(Utils.getNearbyPlayerInSurvival(headlessHorseman.getLocation(), 30, 20, 30));
         }
 
         if (pattern == AttackPattern.SUMMON && tick == 25) {
@@ -131,7 +127,7 @@ public class HeadlessHorseman extends CustomBoss {
             return;
         }
 
-        final Entity target = headlessHorseman.getTarget();
+        Entity target = headlessHorseman.getTarget();
         if (!(target instanceof Player player)) {
             return;
         }
@@ -165,14 +161,14 @@ public class HeadlessHorseman extends CustomBoss {
                 }
 
                 Location newLocation = player.getLocation();
-                if (NumberConversions.square(playerLocation.getX() - newLocation.getX())
-                        + NumberConversions.square(playerLocation.getY() - newLocation.getY()) >= Math.pow(0.72, 2)) {
+                if (Math.pow(playerLocation.getX() - newLocation.getX(), 2)
+                        + Math.pow(playerLocation.getY() - newLocation.getY(), 2) >= Math.pow(0.72, 2)) {
                     return;
                 }
 
-                EntityDamageEvent e = new EntityDamageEvent(player, DamageCause.CUSTOM, 12);
-                Bukkit.getServer().getPluginManager().callEvent(e);
-                if (!e.isCancelled()) {
+                EntityDamageEvent event = new EntityDamageEvent(player, DamageCause.CUSTOM, 12);
+                Bukkit.getServer().getPluginManager().callEvent(event);
+                if (!event.isCancelled()) {
                     player.damage(12.4);
                     Utils.dealDamageBypassingArmor(player, 1.72);
                 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
@@ -3,7 +3,6 @@ package me.gallowsdove.foxymachines.implementation.mobs;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.DyeColor;
-import org.bukkit.GameMode;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -38,22 +37,18 @@ public class Helldog extends CustomMob {
         Wolf helldog = (Wolf) entity;
 
         entity.setFireTicks(999999999);
-        Collection<Entity> entities = helldog.getWorld().getNearbyEntities(helldog.getLocation(), 1.54, 1.54, 1.54);
 
-        for (Entity player : entities) {
-            if (player instanceof Player && ((Player) player).getGameMode() == GameMode.SURVIVAL) {
-                if (tick % 10 == 0)
-                    helldog.attack(player);
+        if (tick % 10 == 0) {
+            Collection<Player> players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 1.54);
+            for (Player player : players) {
+                helldog.attack(player);
             }
         }
 
         if (tick % 20 == 0) {
-            entities = helldog.getWorld().getNearbyEntities(helldog.getLocation(), 16, 16, 16);
-
-            for (Entity player : entities) {
-                if (player instanceof Player && ((Player) player).getGameMode() == GameMode.SURVIVAL) {
-                    helldog.setTarget((LivingEntity) player);
-                }
+            Collection<Player> players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 16);
+            for (Player player : players) {
+                helldog.setTarget(player);
             }
         }
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
@@ -3,6 +3,7 @@ package me.gallowsdove.foxymachines.implementation.mobs;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.DyeColor;
+import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -12,7 +13,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
+import java.util.List;
 
 public class Helldog extends CustomMob {
 
@@ -38,39 +39,53 @@ public class Helldog extends CustomMob {
 
         entity.setFireTicks(999999999);
 
-        if (tick % 10 == 0) {
-            Collection<Player> players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 1.54);
-            for (Player player : players) {
-                helldog.attack(player);
-            }
-        }
-
+        List<Player> players = null;
         if (tick % 20 == 0) {
-            Collection<Player> players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 16);
-            for (Player player : players) {
-                helldog.setTarget(player);
+            Location location = helldog.getLocation();
+            LivingEntity target = helldog.getTarget();
+            if (!(target instanceof Player) || !Utils.isWithinBox(location, target.getLocation(), 16)) {
+                players = Utils.getNearbyPlayersInSurvival(location, 16);
+                helldog.setTarget(players.isEmpty() ? null : players.get(0));
             }
         }
+
+        if (tick % 10 == 0) {
+            if (players == null) {
+                players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 1.54);
+                for (Player player : players) {
+                    helldog.attack(player);
+                }
+                return;
+            }
+
+            for (Player player : players) {
+                if (Utils.isWithinBox(helldog.getLocation(), player.getLocation(), 1.54)) {
+                    helldog.attack(player);
+                }
+            }
+        }
+
+
     }
 
     @Override
-    public void onDeath(@Nonnull EntityDeathEvent e) {
-        super.onDeath(e);
+    public void onDeath(@Nonnull EntityDeathEvent event) {
+        super.onDeath(event);
 
-        e.getDrops().clear();
+        event.getDrops().clear();
     }
 
     @Override
-    protected void onAttack(@Nonnull EntityDamageByEntityEvent e) {
-        if (!e.isCancelled()) {
-            Utils.dealDamageBypassingArmor((LivingEntity) e.getEntity(), (e.getDamage() - e.getFinalDamage()) * 0.2);
+    protected void onAttack(@Nonnull EntityDamageByEntityEvent event) {
+        if (!event.isCancelled()) {
+            Utils.dealDamageBypassingArmor((LivingEntity) event.getEntity(), (event.getDamage() - event.getFinalDamage()) * 0.2);
         }
     }
 
     @Override
-    protected void onTarget(@Nonnull EntityTargetEvent e) {
-        if (!(e.getTarget() instanceof Player)) {
-            e.setCancelled(true);
+    protected void onTarget(@Nonnull EntityTargetEvent event) {
+        if (!(event.getTarget() instanceof Player)) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
@@ -3,7 +3,6 @@ package me.gallowsdove.foxymachines.implementation.mobs;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.DyeColor;
-import org.bukkit.Location;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -41,18 +40,13 @@ public class Helldog extends CustomMob {
 
         List<Player> players = null;
         if (tick % 20 == 0) {
-            Location location = helldog.getLocation();
-            LivingEntity target = helldog.getTarget();
-            if (!(target instanceof Player) || !Utils.isWithinBox(location, target.getLocation(), 16)) {
-                players = Utils.getNearbyPlayersInSurvival(location, 16);
-                helldog.setTarget(players.isEmpty() ? null : players.get(0));
-            }
+            players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 16);
+            helldog.setTarget(players.isEmpty() ? null : players.get(0));
         }
 
         if (tick % 10 == 0) {
             if (players == null) {
-                players = Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 1.54);
-                for (Player player : players) {
+                for (Player player : Utils.getNearbyPlayersInSurvival(helldog.getLocation(), 1.54)) {
                     helldog.attack(player);
                 }
                 return;

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Helldog.java
@@ -60,6 +60,8 @@ public class Helldog extends CustomMob {
 
     @Override
     public void onDeath(@Nonnull EntityDeathEvent e) {
+        super.onDeath(e);
+
         e.getDrops().clear();
     }
 

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Pixie.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Pixie.java
@@ -24,6 +24,8 @@ public class Pixie extends CustomMob {
 
     @Override
     public void onDeath(@Nonnull EntityDeathEvent e) {
+        super.onDeath(e);
+
         e.getDrops().clear();
     }
 

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Pixie.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/Pixie.java
@@ -23,23 +23,23 @@ public class Pixie extends CustomMob {
     }
 
     @Override
-    public void onDeath(@Nonnull EntityDeathEvent e) {
-        super.onDeath(e);
+    public void onDeath(@Nonnull EntityDeathEvent event) {
+        super.onDeath(event);
 
-        e.getDrops().clear();
+        event.getDrops().clear();
     }
 
     @Override
-    protected void onAttack(@Nonnull EntityDamageByEntityEvent e) {
-        if (!e.isCancelled()) {
-            Utils.dealDamageBypassingArmor((LivingEntity) e.getEntity(), (e.getDamage() - e.getFinalDamage()) * 0.2);
+    protected void onAttack(@Nonnull EntityDamageByEntityEvent event) {
+        if (!event.isCancelled()) {
+            Utils.dealDamageBypassingArmor((LivingEntity) event.getEntity(), (event.getDamage() - event.getFinalDamage()) * 0.2);
         }
     }
 
     @Override
-    protected void onTarget(@Nonnull EntityTargetEvent e) {
-        if (!(e.getTarget() instanceof Player)) {
-            e.setCancelled(true);
+    protected void onTarget(@Nonnull EntityTargetEvent event) {
+        if (!(event.getTarget() instanceof Player)) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
@@ -87,7 +87,7 @@ public class PixieQueen extends CustomBoss {
             pattern = AttackPattern.IDLE;
         }
 
-        mob.getPersistentDataContainer().set(PATTERN_KEY, PersistentDataType.SHORT, pattern);
+        PersistentDataAPI.setShort(mob, PATTERN_KEY, pattern);
     }
 
     @Override

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
@@ -149,7 +149,7 @@ public class PixieQueen extends CustomBoss {
     }
 
     private void summonPixieSwarm(Location loc) {
-        CustomMob mob = CustomMob.getByID("PIXIE");
+        CustomMob mob = CustomMob.getById("PIXIE");
         if (mob == null) {
             FoxyMachines.getInstance().getLogger().warning("Could not spawn Pixies! Please report this to the github!");
             return;

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
@@ -1,6 +1,7 @@
 package me.gallowsdove.foxymachines.implementation.mobs;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.data.persistent.PersistentDataAPI;
 import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
 import me.gallowsdove.foxymachines.abstracts.CustomBoss;
@@ -94,7 +95,7 @@ public class PixieQueen extends CustomBoss {
         super.onMobTick(entity, tick);
 
         Vex pixieQueen = (Vex) entity;
-        short pattern = entity.getPersistentDataContainer().get(PATTERN_KEY, PersistentDataType.SHORT);
+        short pattern = PersistentDataAPI.getShort(entity, PATTERN_KEY);
 
         if (pattern == AttackPattern.SUMMON && tick == 25) {
             summonPixieSwarm(pixieQueen.getLocation());
@@ -110,22 +111,18 @@ public class PixieQueen extends CustomBoss {
                 }
             }
 
-            LivingEntity target = pixieQueen.getTarget();
-            if (!(target instanceof Player) || !Utils.isWithinBox(location, target.getLocation(), 10)) {
-                Player player = Utils.getNearbyPlayerInSurvival(location, 10);
-                pixieQueen.setCharging(false);
-                pixieQueen.setTarget(player);
-                target = player;
-            }
+            Player player = Utils.getNearbyPlayerInSurvival(location, 10);
+            pixieQueen.setCharging(false);
+            pixieQueen.setTarget(player);
 
-            if (target == null) {
+            if (player == null) {
                 return;
             }
 
             if ((tick + 2) % 3 == 0) {
                 try {
                     // TODO: Find out why this sometimes throws an error
-                    pixieQueen.setVelocity(target.getLocation().toVector().subtract(location.toVector()).normalize().multiply(0.32));
+                    pixieQueen.setVelocity(player.getLocation().toVector().subtract(location.toVector()).normalize().multiply(0.32));
                 } catch (IllegalArgumentException ignored) { }
             }
             return;

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
@@ -137,10 +137,13 @@ public class PixieQueen extends CustomBoss {
                 arrow.setGlowing(true);
                 arrow.setSilent(true);
                 arrow.setGravity(false);
+                arrow.setPersistent(false);
                 try {
                     // TODO: Find out why this sometimes throws an error
                     arrow.setVelocity(pixieQueen.getTarget().getLocation().toVector().subtract(pixieQueen.getLocation().toVector()).normalize().multiply(1.42));
-                } catch (IllegalArgumentException ignored) {}
+                } catch (IllegalArgumentException ignored) {
+                    arrow.remove();
+                }
             }
         }
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/PixieQueen.java
@@ -21,7 +21,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
 public class PixieQueen extends CustomBoss {
@@ -57,16 +57,16 @@ public class PixieQueen extends CustomBoss {
     }
 
     @Override
-    protected void onTarget(@Nonnull EntityTargetEvent e) {
-        if (!(e.getTarget() instanceof Player)) {
-            e.setCancelled(true);
+    protected void onTarget(@Nonnull EntityTargetEvent event) {
+        if (!(event.getTarget() instanceof Player)) {
+            event.setCancelled(true);
         }
     }
 
     @Override
-    protected void onAttack(@Nonnull EntityDamageByEntityEvent e) {
-        if (!e.isCancelled()) {
-            Utils.dealDamageBypassingArmor((LivingEntity) e.getEntity(), (e.getDamage() - e.getFinalDamage()) * 0.12);
+    protected void onAttack(@Nonnull EntityDamageByEntityEvent event) {
+        if (!event.isCancelled()) {
+            Utils.dealDamageBypassingArmor((LivingEntity) event.getEntity(), (event.getDamage() - event.getFinalDamage()) * 0.12);
         }
     }
 
@@ -102,24 +102,31 @@ public class PixieQueen extends CustomBoss {
         }
 
         if (pattern == AttackPattern.CHARGE) {
+            Location location = pixieQueen.getLocation();
             if (tick % 10 == 0) {
-                Collection<Player> players = Utils.getNearbyPlayersInSurvival(pixieQueen.getLocation(), 1.6);
+                List<Player> players = Utils.getNearbyPlayersInSurvival(location, 1.6);
                 for (Player player : players) {
                     pixieQueen.attack(player);
                 }
             }
 
-            Collection<Player> players = Utils.getNearbyPlayersInSurvival(pixieQueen.getLocation(), 10);
-            for (Player player : players) {
-                pixieQueen.setTarget(pixieQueen);
+            LivingEntity target = pixieQueen.getTarget();
+            if (!(target instanceof Player) || !Utils.isWithinBox(location, target.getLocation(), 10)) {
+                Player player = Utils.getNearbyPlayerInSurvival(location, 10);
                 pixieQueen.setCharging(false);
+                pixieQueen.setTarget(player);
+                target = player;
+            }
 
-                if ((tick + 2) % 3 == 0) {
-                    try {
-                        // TODO: Find out why this sometimes throws an error
-                        pixieQueen.setVelocity(player.getLocation().toVector().subtract(pixieQueen.getLocation().toVector()).normalize().multiply(0.32));
-                    } catch (IllegalArgumentException ignored) { }
-                }
+            if (target == null) {
+                return;
+            }
+
+            if ((tick + 2) % 3 == 0) {
+                try {
+                    // TODO: Find out why this sometimes throws an error
+                    pixieQueen.setVelocity(target.getLocation().toVector().subtract(location.toVector()).normalize().multiply(0.32));
+                } catch (IllegalArgumentException ignored) { }
             }
             return;
         }
@@ -133,22 +140,25 @@ public class PixieQueen extends CustomBoss {
                 arrow.setGlowing(true);
                 arrow.setSilent(true);
                 arrow.setGravity(false);
-                arrow.setVelocity(pixieQueen.getTarget().getLocation().toVector().subtract(pixieQueen.getLocation().toVector()).normalize().multiply(1.42));
+                try {
+                    // TODO: Find out why this sometimes throws an error
+                    arrow.setVelocity(pixieQueen.getTarget().getLocation().toVector().subtract(pixieQueen.getLocation().toVector()).normalize().multiply(1.42));
+                } catch (IllegalArgumentException ignored) {}
             }
         }
     }
 
     @Override
-    public void onDeath(@Nonnull EntityDeathEvent e) {
-        super.onDeath(e);
+    public void onDeath(@Nonnull EntityDeathEvent event) {
+        super.onDeath(event);
 
-        e.getDrops().clear();
-        Location loc = e.getEntity().getLocation();
+        event.getDrops().clear();
+        Location loc = event.getEntity().getLocation();
         loc.getWorld().dropItemNaturally(loc, new SlimefunItemStack(Items.PIXIE_QUEEN_HEART, 1));
         loc.getWorld().spawn(loc, ExperienceOrb.class).setExperience(1400 + ThreadLocalRandom.current().nextInt(600));
     }
 
-    private void summonPixieSwarm(Location loc) {
+    private void summonPixieSwarm(Location location) {
         CustomMob mob = CustomMob.getById("PIXIE");
         if (mob == null) {
             FoxyMachines.getInstance().getLogger().warning("Could not spawn Pixies! Please report this to the github!");
@@ -158,12 +168,12 @@ public class PixieQueen extends CustomBoss {
 
         ThreadLocalRandom random = ThreadLocalRandom.current();
         for (int i = 0; i < random.nextInt(2) + 3; i++) {
-            mob.spawn(new Location(loc.getWorld(), loc.getX() + random.nextDouble(-2, 2),
-                    loc.getY() + random.nextDouble(1.2, 2.4), loc.getZ() + random.nextDouble(-2, 2)));
+            mob.spawn(new Location(location.getWorld(), location.getX() + random.nextDouble(-2, 2),
+                    location.getY() + random.nextDouble(1.2, 2.4), location.getZ() + random.nextDouble(-2, 2)));
         }
 
         for (int i = 0; i < 10; i++) {
-            loc.getWorld().spawnParticle(Particle.VILLAGER_HAPPY, loc, 1, random.nextDouble(-1.5, 1.5),
+            location.getWorld().spawnParticle(Particle.VILLAGER_HAPPY, location, 1, random.nextDouble(-1.5, 1.5),
                     random.nextDouble(-1.2, 2.4), random.nextDouble(-1.5, 1.5), 0);
         }
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
@@ -34,20 +34,20 @@ public class RiddenSkeletonHorse extends CustomMob {
     }
 
     @Override
-    protected void onHit(@Nonnull EntityDamageEvent e) {
-        if (RESISTANCES.contains(e.getCause())) {
-            e.setCancelled(true);
+    protected void onHit(@Nonnull EntityDamageEvent event) {
+        if (RESISTANCES.contains(event.getCause())) {
+            event.setCancelled(true);
         }
 
-        SkeletonHorse horse = (SkeletonHorse) e.getEntity();
+        SkeletonHorse horse = (SkeletonHorse) event.getEntity();
 
-        if (e.isCancelled()) {
+        if (event.isCancelled()) {
             return;
         }
 
         for (Entity entity : horse.getPassengers()) {
             if (entity instanceof LivingEntity passenger && CustomMob.getByEntity(entity) instanceof CustomBoss boss) {
-                double finalHealth = horse.getHealth() + passenger.getHealth() - e.getFinalDamage();
+                double finalHealth = horse.getHealth() + passenger.getHealth() - event.getFinalDamage();
                 if (finalHealth > 0) {
                     boss.updateBossBar(passenger, finalHealth / (passenger.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() +
                             horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()));
@@ -57,12 +57,12 @@ public class RiddenSkeletonHorse extends CustomMob {
     }
 
     @Override
-    protected void onDeath(@Nonnull EntityDeathEvent e) {
-        super.onDeath(e);
+    protected void onDeath(@Nonnull EntityDeathEvent event) {
+        super.onDeath(event);
 
-        e.getDrops().clear();
+        event.getDrops().clear();
 
-        List<Entity> passengers = e.getEntity().getPassengers();
+        List<Entity> passengers = event.getEntity().getPassengers();
         for (Entity passenger: passengers) {
             if (passenger instanceof LivingEntity livingEntity) {
                 livingEntity.setHealth(0);

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
@@ -18,8 +18,8 @@ import java.util.List;
 import java.util.Set;
 
 public class RiddenSkeletonHorse extends CustomMob {
-    private static final Set<DamageCause> RESISTANCES = Set.of(new DamageCause[] {
-            DamageCause.CRAMMING, DamageCause.POISON, DamageCause.BLOCK_EXPLOSION, DamageCause.ENTITY_EXPLOSION});
+    private static final Set<DamageCause> RESISTANCES = Set.of(
+            DamageCause.CRAMMING, DamageCause.POISON, DamageCause.BLOCK_EXPLOSION, DamageCause.ENTITY_EXPLOSION);
 
     public RiddenSkeletonHorse() {
         super("SKELETON_HORSE", "Skeleton Horse", EntityType.SKELETON_HORSE, 132);
@@ -60,13 +60,15 @@ public class RiddenSkeletonHorse extends CustomMob {
 
     @Override
     protected void onDeath(@Nonnull EntityDeathEvent e) {
+        super.onDeath(e);
+
         e.getDrops().clear();
 
         List<Entity> passengers = e.getEntity().getPassengers();
 
         for (Entity passenger: passengers) {
-            if (passenger instanceof LivingEntity) {
-                ((LivingEntity) passenger).setHealth(0);
+            if (passenger instanceof LivingEntity livingEntity) {
+                livingEntity.setHealth(0);
             }
         }
     }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/mobs/RiddenSkeletonHorse.java
@@ -18,8 +18,7 @@ import java.util.List;
 import java.util.Set;
 
 public class RiddenSkeletonHorse extends CustomMob {
-    private static final Set<DamageCause> RESISTANCES = Set.of(
-            DamageCause.CRAMMING, DamageCause.POISON, DamageCause.BLOCK_EXPLOSION, DamageCause.ENTITY_EXPLOSION);
+    private static final Set<DamageCause> RESISTANCES = Set.of(DamageCause.CRAMMING, DamageCause.POISON, DamageCause.BLOCK_EXPLOSION, DamageCause.ENTITY_EXPLOSION);
 
     public RiddenSkeletonHorse() {
         super("SKELETON_HORSE", "Skeleton Horse", EntityType.SKELETON_HORSE, 132);
@@ -42,17 +41,16 @@ public class RiddenSkeletonHorse extends CustomMob {
 
         SkeletonHorse horse = (SkeletonHorse) e.getEntity();
 
-        if (!e.isCancelled()) {
-            for (Entity entity : horse.getPassengers()) {
-                if (entity instanceof LivingEntity passenger) {
-                    CustomMob mob = RiddenSkeletonHorse.getByEntity(entity);
-                    if (mob instanceof CustomBoss boss) {
-                        double finalHealth = horse.getHealth() + passenger.getHealth() - e.getFinalDamage();
-                        if (finalHealth > 0) {
-                            boss.updateBossBar(passenger, finalHealth / (passenger.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() +
-                                    horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()));
-                        }
-                    }
+        if (e.isCancelled()) {
+            return;
+        }
+
+        for (Entity entity : horse.getPassengers()) {
+            if (entity instanceof LivingEntity passenger && CustomMob.getByEntity(entity) instanceof CustomBoss boss) {
+                double finalHealth = horse.getHealth() + passenger.getHealth() - e.getFinalDamage();
+                if (finalHealth > 0) {
+                    boss.updateBossBar(passenger, finalHealth / (passenger.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue() +
+                            horse.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue()));
                 }
             }
         }
@@ -65,7 +63,6 @@ public class RiddenSkeletonHorse extends CustomMob {
         e.getDrops().clear();
 
         List<Entity> passengers = e.getEntity().getPassengers();
-
         for (Entity passenger: passengers) {
             if (passenger instanceof LivingEntity livingEntity) {
                 livingEntity.setHealth(0);

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoadListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoadListener.java
@@ -1,0 +1,40 @@
+package me.gallowsdove.foxymachines.listeners;
+
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.ChunkPosition;
+import me.gallowsdove.foxymachines.abstracts.CustomMob;
+import me.gallowsdove.foxymachines.implementation.materials.GhostBlock;
+import org.bukkit.Chunk;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.ChunkLoadEvent;
+
+import javax.annotation.Nonnull;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ChunkLoadListener implements Listener {
+    private static final Set<ChunkPosition> SCANNED_CHUNKS = new HashSet<>();
+
+    @EventHandler
+    public void onChunkLoad(@Nonnull ChunkLoadEvent e) {
+        Chunk chunk = e.getChunk();
+        ChunkPosition chunkPosition = new ChunkPosition(chunk);
+        if (SCANNED_CHUNKS.contains(chunkPosition)) {
+            return;
+        }
+        SCANNED_CHUNKS.add(chunkPosition);
+
+        for (Entity entity : chunk.getEntities()) {
+            CustomMob customMob = CustomMob.getByEntity(entity);
+            if (customMob != null) {
+                customMob.cacheEntity(entity);
+            }
+
+            if (entity instanceof FallingBlock && GhostBlock.isGhostBlock(entity)) {
+                GhostBlock.BLOCK_CACHE.add(entity.getUniqueId());
+            }
+        }
+    }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoaderListener.java
+++ b/src/main/java/me/gallowsdove/foxymachines/listeners/ChunkLoaderListener.java
@@ -46,7 +46,7 @@ public class ChunkLoaderListener implements Listener {
         Config cfg = new Config(FoxyMachines.getInstance());
         if (!p.hasPermission("foxymachines.bypass-chunk-loader-limit")) {
             int max = cfg.getInt("max-chunk-loaders");
-            if(max != 0 && max < i) {
+            if (max != 0 && max < i) {
                 p.sendMessage(ChatColor.LIGHT_PURPLE + "Maximum amount of chunk loaders already placed: " + max);
                 e.setCancelled(true);
                 return;

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/GhostBlockTask.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/GhostBlockTask.java
@@ -2,20 +2,24 @@ package me.gallowsdove.foxymachines.tasks;
 
 import me.gallowsdove.foxymachines.implementation.materials.GhostBlock;
 import org.bukkit.Bukkit;
-import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.FallingBlock;
-import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.HashSet;
+import java.util.UUID;
 
 public class GhostBlockTask extends BukkitRunnable {
     @Override
     public void run() {
-        for (World world : Bukkit.getWorlds()) {
-            for (FallingBlock block : world.getEntitiesByClass(FallingBlock.class)) {
-                if (block.getPersistentDataContainer().has(GhostBlock.KEY, PersistentDataType.STRING)) {
-                    block.setTicksLived(1);
-                }
+        for (UUID uuid : new HashSet<>(GhostBlock.BLOCK_CACHE)) {
+            Entity entity = Bukkit.getEntity(uuid);
+            if (!(entity instanceof FallingBlock)) {
+                GhostBlock.BLOCK_CACHE.remove(uuid);
+                continue;
             }
+
+            entity.setTicksLived(1);
         }
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -22,10 +22,10 @@ public class MobTicker implements Runnable {
         }
 
         for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
-            final CustomMob customMob = entry.getKey();
-            final Set<UUID> entities = entry.getValue();
+            CustomMob customMob = entry.getKey();
+            Set<UUID> entities = entry.getValue();
             for (UUID uuid : new HashSet<>(entities)) {
-                final Entity entity = Bukkit.getEntity(uuid);
+                Entity entity = Bukkit.getEntity(uuid);
                 if (!(entity instanceof LivingEntity livingEntity)) {
                     entities.remove(uuid);
                     continue;

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -22,15 +23,17 @@ public class MobTicker implements Runnable {
         for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
             CustomMob customMob = entry.getKey();
             Set<UUID> entities = entry.getValue();
+            Set<UUID> newEntities = new HashSet<>();
             for (UUID uuid : new HashSet<>(entities)) {
                 Entity entity = Bukkit.getEntity(uuid);
                 if (!(entity instanceof LivingEntity livingEntity)) {
-                    entities.remove(uuid);
                     continue;
                 }
 
+                newEntities.add(uuid);
                 customMob.onMobTick(livingEntity, tick);
             }
+            entry.setValue(newEntities);
         }
 
         if (tick == 100) {

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -1,9 +1,7 @@
 package me.gallowsdove.foxymachines.tasks;
 
-import me.gallowsdove.foxymachines.abstracts.CustomBoss;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
 import org.bukkit.Bukkit;
-import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -4,9 +4,15 @@ import me.gallowsdove.foxymachines.abstracts.CustomBoss;
 import me.gallowsdove.foxymachines.abstracts.CustomMob;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 
-public class MobTicker implements Runnable{
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+public class MobTicker implements Runnable {
     int tick = 0;
 
     @Override
@@ -15,17 +21,20 @@ public class MobTicker implements Runnable{
             mob.onUniqueTick(tick);
         }
 
-        for (World world: Bukkit.getWorlds()) {
-            for (LivingEntity entity : world.getLivingEntities()) {
-                CustomMob mob = CustomMob.getByEntity(entity);
-                if (mob != null) {
-                    mob.onMobTick(entity, tick);
-                    if (mob instanceof CustomBoss customBoss && tick == 100) {
-                        customBoss.onBossPattern(entity);
-                    }
+        for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
+            final CustomMob customMob = entry.getKey();
+            final Set<UUID> entities = entry.getValue();
+            for (UUID uuid : new HashSet<>(entities)) {
+                final Entity entity = Bukkit.getEntity(uuid);
+                if (!(entity instanceof LivingEntity livingEntity)) {
+                    entities.remove(uuid);
+                    continue;
                 }
+
+                customMob.onMobTick(livingEntity, tick);
             }
         }
+
         if (tick == 100) {
             tick = 0;
         }

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -22,17 +22,19 @@ public class MobTicker implements Runnable {
         for (Map.Entry<CustomMob, Set<UUID>> entry : CustomMob.MOB_CACHE.entrySet()) {
             CustomMob customMob = entry.getKey();
             Set<UUID> entities = entry.getValue();
-            Set<UUID> newEntities = new HashSet<>();
             for (UUID uuid : new HashSet<>(entities)) {
                 Entity entity = Bukkit.getEntity(uuid);
                 if (!(entity instanceof LivingEntity livingEntity)) {
+                    if (entity != null) {
+                        entity.remove();
+                    }
+
+                    customMob.uncacheEntity(uuid);
                     continue;
                 }
 
-                newEntities.add(uuid);
                 customMob.onMobTick(livingEntity, tick);
             }
-            entry.setValue(newEntities);
         }
 
         if (tick == 100) {

--- a/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
+++ b/src/main/java/me/gallowsdove/foxymachines/tasks/MobTicker.java
@@ -5,7 +5,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
+++ b/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
@@ -10,8 +10,9 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
-import java.util.HashSet;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Utils {
     private Utils() {}
@@ -48,22 +49,50 @@ public class Utils {
         return amount;
     }
 
-    public static Collection<Player> getNearbyPlayersInSurvival(Location location, double radius) {
+    public static boolean isWithinBox(Location centerLocation, Location location, double radius) {
+        return isWithinBox(centerLocation, location, radius, radius, radius);
+    }
+
+    public static boolean isWithinBox(Location centerLocation, Location location, double x, double y, double z) {
+        return Math.abs(centerLocation.getX() - location.getX()) <= x
+                && Math.abs(centerLocation.getY() - location.getY()) <= y
+                && Math.abs(centerLocation.getZ() - location.getZ()) <= z;
+    }
+
+    public static List<Player> getNearbyPlayersInSurvival(Location location, double radius) {
         return getNearbyPlayersInSurvival(location, radius, radius, radius);
     }
 
-    public static Collection<Player> getNearbyPlayersInSurvival(Location location, double x, double y, double z) {
+    public static List<Player> getNearbyPlayersInSurvival(Location location, double x, double y, double z) {
         World world = location.getWorld();
         if (world == null) {
-            return new HashSet<>();
+            return new ArrayList<>();
         }
 
-        Collection<Player> players = new HashSet<>();
+        List<Player> players = new ArrayList<>();
         for (Entity entity : world.getNearbyEntities(location, x, y, z)) {
             if (entity instanceof Player player && player.getGameMode() == GameMode.SURVIVAL) {
                 players.add(player);
             }
         }
         return players;
+    }
+
+    public static Player getNearbyPlayerInSurvival(Location location, double radius) {
+        return getNearbyPlayerInSurvival(location, radius, radius, radius);
+    }
+
+    public static @Nullable Player getNearbyPlayerInSurvival(Location location, double x, double y, double z) {
+        World world = location.getWorld();
+        if (world == null) {
+            return null;
+        }
+
+        for (Entity entity : world.getNearbyEntities(location, x, y, z)) {
+            if (entity instanceof Player player && player.getGameMode() == GameMode.SURVIVAL) {
+                return player;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
+++ b/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
@@ -1,10 +1,17 @@
 package me.gallowsdove.foxymachines.utils;
 
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.HashSet;
 
 public class Utils {
     private Utils() {}
@@ -39,5 +46,24 @@ public class Utils {
         }
 
         return amount;
+    }
+
+    public static Collection<Player> getNearbyPlayersInSurvival(Location location, double radius) {
+        return getNearbyPlayersInSurvival(location, radius, radius, radius);
+    }
+
+    public static Collection<Player> getNearbyPlayersInSurvival(Location location, double x, double y, double z) {
+        World world = location.getWorld();
+        if (world == null) {
+            return new HashSet<>();
+        }
+
+        Collection<Player> players = new HashSet<>();
+        for (Entity entity : world.getNearbyEntities(location, x, y, z)) {
+            if (entity instanceof Player player && player.getGameMode() == GameMode.SURVIVAL) {
+                players.add(player);
+            }
+        }
+        return players;
     }
 }


### PR DESCRIPTION
## Testing Status
Currently this PR is not tested in any way, I need to do _**extensive testing**_

## Description
This PR aims to rewrite the custom mob system (without any changes to the end functionality hopefully) to have improved performance, code readability and just cleanup in general.

## Proposed generic changes
- Added `Utils#getNearbyPlayersInSurvival(Location, double, double, double)` this method is just a utility since you had loops frequently that all did the same thing, filter down to players in survival, there is also an overloaded method with just one double if the radius on each axis is identical
- Replaced various instanceof with instanceof casts
- Changed some annotations to use `@ParametersNonnullByDefault` instead of a lot of `@Nonnull` annotations
- Marking constants final
- Removing unnecessary boxing or overloading
- Re-arranging conditions and method calls to be more performant
- Combining nested if statements
- Switched to guard statements to avoid a ton of indentation

## Proposed changes to CustomMob
- Made the constructor protected since its an abstract class
- Added `SCANNED_CHUNKS` a Set of ChunkPositions, and `MOB_CACHE` a map of `CustomMob -> Set<UUID>`
   - Added another EventHandler method to the register listener, it is the chunk load event, if the loaded chunks position is not in scanned chunks it will go through all of the entities and cache them if they are custom, **it will only do this once per chunk**
- Added `cacheEntity(Entity)` and `uncacheEntity(Entity)` respectively
   - There is now a default in the `onEntityDeath` that calls `uncacheEntity`, and I have added the annotation `@OverridingMethodsMustInvokeSuper` and followed that in all the overriding methods as well to ensure that it is always called.
   - The `spawn` event now calls `cacheEntity`

## Proposed changes to MobTicker
- Replaced the `getWorlds.getLivingEntities` calls with an iteration over the `MOB_CACHE` in `CustomMob`

## Proposed changes to CustomBoss
- Made the constructor protected since its an abstract class
- Added an override to `onMobTick` this handles the `onBossPattern` method, this was previously handled in MobTicker, this method also has the `@OverridingMethodsMustInvokeSuper`

## Proposed changes to HeadlessHorseman
- Replacing the manual distance checks with builtin methods
- Re-arranged a lot within `onMobTick` to make it more readable, more performant, etc, etc
- Replaced the `assert helldog != null` with a null check and warning to the log, an assertion error is not very clear to the server administrators

## Proposed changes to PixieQueen
- Basically all the same things changed in HeadlessHorseman just for pixie queen