### PR TITLE
[Chore] Prevent Specific Slimefun Items from being made Unbreakable

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
+++ b/src/main/java/me/gallowsdove/foxymachines/FoxyMachines.java
@@ -11,6 +11,7 @@ import me.gallowsdove.foxymachines.commands.KillallCommand;
 import me.gallowsdove.foxymachines.commands.QuestCommand;
 import me.gallowsdove.foxymachines.commands.SacrificialAltarCommand;
 import me.gallowsdove.foxymachines.commands.SummonCommand;
+import me.gallowsdove.foxymachines.implementation.consumables.UnbreakableRune;
 import me.gallowsdove.foxymachines.implementation.machines.ForcefieldDome;
 import me.gallowsdove.foxymachines.implementation.tools.BerryBushTrimmer;
 import me.gallowsdove.foxymachines.listeners.*;
@@ -51,6 +52,7 @@ public class FoxyMachines extends AbstractAddon {
 
         QuestUtils.init();
         AbstractWand.init();
+        UnbreakableRune.init();
         ItemSetup.INSTANCE.init();
         ResearchSetup.INSTANCE.init();
 

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/UnbreakableRune.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/UnbreakableRune.java
@@ -85,7 +85,7 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
         }
 
         Location l = rune.getLocation();
-        Collection<Entity> entities = l.getWorld().getNearbyEntities(l, RANGE, RANGE, RANGE, this::findCompatibleItem);
+        Collection<Entity> entities = l.getWorld().getNearbyEntities(l, RANGE, RANGE, RANGE, entity -> findCompatibleItem(p, entity));
         Optional<Entity> optional = entities.stream().findFirst();
 
         if (optional.isPresent()) {
@@ -118,10 +118,10 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
         }
     }
 
-    private boolean findCompatibleItem(Entity entity) {
+    private boolean findCompatibleItem(Player player, Entity entity) {
         if (entity instanceof Item item) {
             ItemStack itemStack = item.getItemStack();
-            return !isUnbreakable(itemStack) && !isItem(itemStack) && !isDisallowed(itemStack);
+            return !isUnbreakable(itemStack) && !isItem(itemStack) && !isDisallowed(player, itemStack);
         }
 
         return false;
@@ -151,7 +151,7 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
         }
     }
 
-    public static boolean isDisallowed(ItemStack itemStack) {
+    public static boolean isDisallowed(Player player, ItemStack itemStack) {
         final SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
         if (slimefunItem == null) {
             return false;
@@ -159,6 +159,10 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
 
         final String id = slimefunItem.getId();
         final String addon = slimefunItem.getAddon().getName();
-        return BLACKLIST.containsKey(addon) && BLACKLIST.get(addon).contains(id);
+        if (BLACKLIST.containsKey(addon) && BLACKLIST.get(addon).contains(id)) {
+            player.sendMessage(ChatColor.LIGHT_PURPLE + "You can't make this item unbreakable!");
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/UnbreakableRune.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/consumables/UnbreakableRune.java
@@ -1,6 +1,7 @@
 package me.gallowsdove.foxymachines.implementation.consumables;
 
 import io.github.mooy1.infinitylib.common.Scheduler;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemDropHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
@@ -25,7 +26,6 @@ import java.util.Optional;
 public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
 
     private static final double RANGE = 1.5;
-
 
     public UnbreakableRune() {
         super(Items.TOOLS_ITEM_GROUP, Items.UNBREAKABLE_RUNE, RecipeType.ANCIENT_ALTAR, new ItemStack[] {
@@ -94,7 +94,8 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
 
     private boolean findCompatibleItem(Entity entity) {
         if (entity instanceof Item item) {
-            return !isUnbreakable(item.getItemStack()) && !isItem(item.getItemStack());
+            ItemStack itemStack = item.getItemStack();
+            return !isUnbreakable(itemStack) && !isItem(itemStack) && !isDisallowed(itemStack);
         }
 
         return false;
@@ -103,7 +104,7 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
     public static void setUnbreakable(@Nullable ItemStack item) {
         if (item != null && item.getType() != Material.AIR) {
 
-            if (!isUnbreakable(item)) {
+            if (!isUnbreakable(item) && item.hasItemMeta()) {
                 ItemMeta meta = item.getItemMeta();
 
                 meta.setUnbreakable(true);
@@ -122,5 +123,22 @@ public class UnbreakableRune extends SimpleSlimefunItem<ItemDropHandler> {
         } else {
             return false;
         }
+    }
+
+    public static boolean isDisallowed(ItemStack itemStack) {
+        final SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
+        if (slimefunItem == null) {
+            return false;
+        }
+
+        final String id = slimefunItem.getId();
+        final String addon = slimefunItem.getAddon().getName();
+        if (addon.equals("InfinityExpansion")) {
+            return id.contains("_STRAINER");
+        }
+
+        // If there is anything else in the future it can follow this format ^
+
+        return false;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -32,6 +32,10 @@
 #
 # quest-mobs
 # All mob types that can be required for a quest, for a full list of them go to: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
+#
+# unbreakable-rune-blacklist
+# Any items from addons to blacklist from being usable with the unbreakable rune
+# for ex, by default the strainers from InfinityExpansion are disabled as they do not respect the unbreakable setting
 
 auto-update: true
 max-chunk-loaders: 8
@@ -102,3 +106,8 @@ quest-mobs:
   - ZOMBIE
   - ZOMBIFIED_PIGLIN
   - FOX
+unbreakable-rune-blacklist:
+  InfinityExpansion:
+    - BASIC_STRAINER
+    - ADVANCED_STRAINER
+    - REINFORCED_STRAINER


### PR DESCRIPTION
## Testing Status
Currently this PR is not tested in any way, shouldn't need to do a crazy amount of testing

## Description
This PR just prevents specific items from being made unbreakable, that way players aren't upset when it doesn't work. For now this only applies to infinity expansion strainers, idk if anything else should be prevented. This PR isn't really necessary so if you want feel free to just close it lol.

## Proposed Changes
- Added `UnbreakableRune#isDisallowed` which is called in the `UnbreakableRune#findCompatibleItem` method
  - Checks for a slimefun item, if there isnt one present it returns early. If there is, then get the id and the addon name. The format is checking the addon and then the id. In this case it just checks for infinty exp and containing _STRAINER, any other items that should be ignored can be added following that format 