### PR TITLE
[Fix] Aura Skills not recognizing Wand modified Blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,13 @@
         </dependency>
 
         <dependency>
+            <groupId>dev.aurelium</groupId>
+            <artifactId>auraskills-api-bukkit</artifactId>
+            <version>2.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.Mooy1</groupId>
             <artifactId>InfinityLib</artifactId>
             <version>1.3.9</version>

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
@@ -11,6 +11,7 @@ import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import me.gallowsdove.foxymachines.FoxyMachines;
 import me.gallowsdove.foxymachines.Items;
+import me.gallowsdove.foxymachines.utils.AuraSkillsCompat;
 import me.gallowsdove.foxymachines.utils.SimpleLocation;
 import me.gallowsdove.foxymachines.utils.Utils;
 import org.bukkit.*;
@@ -123,7 +124,12 @@ public abstract class AbstractWand extends SlimefunItem implements NotPlaceable,
                     if (removeItemCharge(e.getItem(), getCostPerBlock() * locs.size())) {
                         inventory.removeItem(blocks);
                         for (Location loc : locs) {
-                            Bukkit.getScheduler().runTask(FoxyMachines.getInstance(), () -> loc.getBlock().setType(material));
+                            Bukkit.getScheduler().runTask(FoxyMachines.getInstance(), () -> {
+                                loc.getBlock().setType(material);
+                                if (Utils.isAuraSkillsLoaded()) {
+                                    AuraSkillsCompat.addPlaceBlock(loc.getBlock());
+                                }
+                            });
                         }
                     } else {
                         player.sendMessage(ChatColor.RED + "Your item doesn't have enough energy for that!");

--- a/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
+++ b/src/main/java/me/gallowsdove/foxymachines/abstracts/AbstractWand.java
@@ -127,7 +127,7 @@ public abstract class AbstractWand extends SlimefunItem implements NotPlaceable,
                             Bukkit.getScheduler().runTask(FoxyMachines.getInstance(), () -> {
                                 loc.getBlock().setType(material);
                                 if (Utils.isAuraSkillsLoaded()) {
-                                    AuraSkillsCompat.addPlaceBlock(loc.getBlock());
+                                    AuraSkillsCompat.addPlacedBlock(loc.getBlock());
                                 }
                             });
                         }

--- a/src/main/java/me/gallowsdove/foxymachines/utils/AuraSkillsCompat.java
+++ b/src/main/java/me/gallowsdove/foxymachines/utils/AuraSkillsCompat.java
@@ -1,0 +1,14 @@
+package me.gallowsdove.foxymachines.utils;
+
+import dev.aurelium.auraskills.api.AuraSkillsBukkitProvider;
+import dev.aurelium.auraskills.api.region.Regions;
+import org.bukkit.block.Block;
+
+public class AuraSkillsCompat {
+    public static void addPlacedBlock(Block block) {
+        Regions regions = AuraSkillsBukkitProvider.getInstance().getRegions();
+        if (regions != null) {
+            regions.addPlacedBlock(block);
+        }
+    }
+}

--- a/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
+++ b/src/main/java/me/gallowsdove/foxymachines/utils/Utils.java
@@ -3,11 +3,16 @@ package me.gallowsdove.foxymachines.utils;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.Bukkit;
 
 import javax.annotation.Nonnull;
 
 public class Utils {
     private Utils() {}
+
+    public static boolean isAuraSkillsLoaded() {
+        return Bukkit.getPluginManager().isPluginEnabled("AuraSkills");
+    }
 
     public static void dealDamageBypassingArmor(LivingEntity entity, double damage) {
         if (damage >= 0) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,35 +1,21 @@
-## CHANGE this to the name of your plugin.
 name: FoxyMachines
-
-## CHANGE this to your username.
-author: GallowsDove
-
-## CHANGE this to a meaninful but short description of your plugin.
-description: Adds tools, machines, items, armor, weapons, bosses and more!
-
-## CHANGE this to the path of the class that extends JavaPlugin.
 main: me.gallowsdove.foxymachines.FoxyMachines
 
-## You can change this to link to your website or repository. You can also remove this line if you want to.
+author: GallowsDove
+description: Adds tools, machines, items, armor, weapons, bosses and more!
 website: https://github.com/GallowsDove/FoxyMachines
 
-## This is required and marks Slimefun as a plugin dependency.
 depend: [Slimefun]
-
-## This value is automatically replaced by the version specified in your pom.xml file, do not change this.
+softdepend: [AuraSkills]
 version: ${project.version}
-
-## This is the minimum minecraft version required to run your plugin.
 api-version: 1.16
 
-## Commands
 commands:
   foxymachines:
     description: foxymachines main command
     usage: /foxymachines <subcommand>
     aliases: [fm, foxy]
 
-## Permissions
 permissions:
   foxymachines.bypass-chunk-loader-limit:
     description: Allows a player with the permission to place an unlimited amount of chunk loaders


### PR DESCRIPTION
## Description
Atm auraskills (previously aurelium skills) does not recognize when a fill wand or sponge wand modifies blocks. This just corrects that.

## Changes
- Added `AuraSkillsCompat`
  - This just has a method to add the placed block, I have this in a separate file that way the server won’t error if AuraSkills is not present
- Added `Utils#isAuraSkillsLoaded`
- Added auraskills bukkit api to `pom.xml`
- Added `AuraSkills` as softdepend to `plugin.yml`
  - I also went ahead and removed the template comments from this file, I can revert this change If you’d like though

## Testing
I just need to test that this does indeed work on servers with and without aurelium skills, I’ll let you know once I have :+1: