### PR TITLE
fix(ImprovementForge): only upgrade 1 item at a time

### DIFF
--- a/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
+++ b/src/main/java/me/gallowsdove/foxymachines/implementation/machines/ImprovementForge.java
@@ -247,7 +247,8 @@ public class ImprovementForge extends SlimefunItem implements EnergyNetComponent
                     }
 
                     ItemStack improvedItem = item.clone();
-                    improvedItem.setType(tools[tier+1][index]);
+                    improvedItem.setAmount(1);
+                    improvedItem.setType(tools[tier + 1][index]);
 
                     if (!menu.fits(improvedItem, getOutputSlots())) {
                         return null;


### PR DESCRIPTION
Since 1.20.6, the tools can be stackable.
This PR set the target item amount to 1 to avoid item duplication.